### PR TITLE
Route idle DDC changes through the brightness controller

### DIFF
--- a/config/hypr/scripts/dim_display.sh
+++ b/config/hypr/scripts/dim_display.sh
@@ -15,20 +15,14 @@ LOG_FILE="${HYPRIDLE_ACTION_LOG:-${CACHE}/hypridle/actions.log}"
 BR_FILE="${RUNTIME_DIR}/hypridle-brightness-level"
 DIM_MARKER="${RUNTIME_DIR}/hypridle-ddc-dimmed"
 
-# Optional: pin a display. Use exactly one token, e.g. "--bus=5"
+# Optional: pin a display. The brightness controller inherits this value.
 : "${DDCUTIL_BUS:=}"
-DDCUTIL_ARGS=()
-[[ -n "$DDCUTIL_BUS" ]] && DDCUTIL_ARGS+=("$DDCUTIL_BUS")
+export DDCUTIL_BUS
 
 mkdir -p "$RUNTIME_DIR" "$(dirname "$LOG_FILE")"
 
 log() {
     printf '%s %s\n' "$(date '+%F %T')" "$*" >>"$LOG_FILE" 2>/dev/null || true
-}
-
-sync_brightness_state() {
-    [[ -x "$BRIGHTNESS_SCRIPT" ]] || return 0
-    HYPR_DDC_NOTIFY=0 "$BRIGHTNESS_SCRIPT" status >/dev/null 2>&1 || true
 }
 
 if [[ -x "$INHIBITOR_SH" ]] && "$INHIBITOR_SH" is-active >/dev/null 2>&1; then
@@ -39,34 +33,32 @@ fi
 
 rm -f "$DIM_MARKER"
 
-# Save current brightness. Do not replace a valid saved value with empty output.
+if [[ ! -x "$BRIGHTNESS_SCRIPT" ]]; then
+    log "DDC dim failed: brightness controller unavailable"
+    exit 1
+fi
+
+# One status read records the current value and primes the controller cache.
+status_output="$(
+    HYPR_DDC_NOTIFY=0 "$BRIGHTNESS_SCRIPT" status 2>/dev/null || true
+)"
 saved_brightness="$(
-    timeout 2 ddcutil "${DDCUTIL_ARGS[@]}" getvcp 0x10 2>/dev/null |
-        awk -F'current value = ' 'NF > 1 { print $2 }' |
-        awk -F',' '{ print $1 }' |
-        tr -dc '0-9' ||
-        true
+    awk -F= '$1 == "cur" { print $2; exit }' <<<"$status_output"
 )"
 
+# Do not replace a valid saved value with empty or malformed output.
 if [[ "$saved_brightness" =~ ^[0-9]+$ ]] &&
    (( saved_brightness >= 0 && saved_brightness <= 100 )); then
     printf '%s\n' "$saved_brightness" >"$BR_FILE"
 fi
 
-if timeout 3 ddcutil "${DDCUTIL_ARGS[@]}" setvcp 0x10 20 >/dev/null 2>&1; then
+# The controller performs the DDC write and publishes the new cached value.
+if HYPR_DDC_NOTIFY=0 "$BRIGHTNESS_SCRIPT" set 20 >/dev/null 2>&1; then
     printf 'dimmed\n' >"$DIM_MARKER"
-    sync_brightness_state
     log "DDC dim applied: brightness 20"
     exit 0
 fi
 
-sleep 0.35
-
-if timeout 3 ddcutil "${DDCUTIL_ARGS[@]}" setvcp 0x10 20 >/dev/null 2>&1; then
-    printf 'dimmed\n' >"$DIM_MARKER"
-    sync_brightness_state
-    log "DDC dim applied after retry: brightness 20"
-else
-    rm -f "$DIM_MARKER"
-    log "DDC dim failed"
-fi
+rm -f "$DIM_MARKER"
+log "DDC dim failed"
+exit 1

--- a/config/hypr/scripts/restore_brightness.sh
+++ b/config/hypr/scripts/restore_brightness.sh
@@ -15,20 +15,14 @@ BR_FILE="${RUNTIME_DIR}/hypridle-brightness-level"
 DIM_MARKER="${RUNTIME_DIR}/hypridle-ddc-dimmed"
 DEFAULT_BRIGHTNESS="70"
 
-# Optional: pin a display. Use exactly one token, e.g. "--bus=5"
+# Optional: pin a display. The brightness controller inherits this value.
 : "${DDCUTIL_BUS:=}"
-DDCUTIL_ARGS=()
-[[ -n "$DDCUTIL_BUS" ]] && DDCUTIL_ARGS+=("$DDCUTIL_BUS")
+export DDCUTIL_BUS
 
 mkdir -p "$RUNTIME_DIR" "$(dirname "$LOG_FILE")"
 
 log() {
     printf '%s %s\n' "$(date '+%F %T')" "$*" >>"$LOG_FILE" 2>/dev/null || true
-}
-
-sync_brightness_state() {
-    [[ -x "$BRIGHTNESS_SCRIPT" ]] || return 0
-    HYPR_DDC_NOTIFY=0 "$BRIGHTNESS_SCRIPT" status >/dev/null 2>&1 || true
 }
 
 # Do nothing unless this idle cycle actually dimmed the monitor.
@@ -51,19 +45,17 @@ if [[ ! "$BRIGHTNESS" =~ ^[0-9]+$ ]] ||
     BRIGHTNESS="$DEFAULT_BRIGHTNESS"
 fi
 
-if timeout 3 ddcutil "${DDCUTIL_ARGS[@]}" setvcp 0x10 "$BRIGHTNESS" >/dev/null 2>&1; then
+if [[ ! -x "$BRIGHTNESS_SCRIPT" ]]; then
+    log "DDC brightness restore failed: brightness controller unavailable"
+    exit 1
+fi
+
+# The controller performs the DDC write and publishes the restored cached value.
+if HYPR_DDC_NOTIFY=0 "$BRIGHTNESS_SCRIPT" set "$BRIGHTNESS" >/dev/null 2>&1; then
     rm -f "$DIM_MARKER"
-    sync_brightness_state
     log "DDC brightness restored: ${BRIGHTNESS}"
     exit 0
 fi
 
-sleep 0.35
-
-if timeout 3 ddcutil "${DDCUTIL_ARGS[@]}" setvcp 0x10 "$BRIGHTNESS" >/dev/null 2>&1; then
-    rm -f "$DIM_MARKER"
-    sync_brightness_state
-    log "DDC brightness restored after retry: ${BRIGHTNESS}"
-else
-    log "DDC brightness restore failed; marker retained"
-fi
+log "DDC brightness restore failed; marker retained"
+exit 1


### PR DESCRIPTION
Removes the remaining raw ddcutil calls from idle dim and restore handling.

- one controller status read saves the pre-dim brightness and primes the cache
- controller set operations perform the DDC write and publish the exact new value to every Waybar watcher
- restore reuses the cached maximum and avoids a redundant post-write DDC query
- existing DDC bus overrides remain inherited