### PR TITLE
Migrate legacy installs without rerunning setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,9 @@ awtarchy
 
 ### Existing-install detection
 
-When `awtarchy-install.sh` detects an existing `~/.local/bin/awtarchy` command, it stops before rerunning the installer and prints the new maintenance commands.
+When `awtarchy-install.sh` finds the installed command, it stops before rerunning the installer and prints the maintenance commands.
+
+When it detects a legacy Awtarchy installation without the command, it installs only `~/.local/bin/awtarchy`, the internal runtime, and version state. It does not reinstall packages or replace managed configs.
 
 To intentionally run the complete installer again:
 
@@ -110,6 +112,8 @@ Dry-run lets you test the installer questionnaire and review the install plan wi
 ```bash
 ./awtarchy-install.sh --dry-run
 ```
+
+For a detected legacy installation, dry-run reports the command migration without installing it.
 
 ## 🧭 Maintenance Menu
 
@@ -199,7 +203,7 @@ awtarchy update --tag v1.0.0
 
 ### Existing installation migration
 
-Existing users need one final repository-based update to install the new command:
+Existing users need one final repository-based migration to install the new command:
 
 ```bash
 cd ~/awtarchy
@@ -207,7 +211,7 @@ git pull --ff-only
 sudo ./awtarchy-install.sh
 ```
 
-Legacy installations without `~/.local/bin/awtarchy` are allowed through this one-time migration. After the command is installed, rerunning `awtarchy-install.sh` prints the new update method and exits unless `--reinstall` is supplied.
+The installer detects the legacy Awtarchy state and performs a command-only migration. Existing packages and managed configs are left untouched. After migration, rerunning `awtarchy-install.sh` prints the maintenance commands and exits unless `--reinstall` is supplied.
 
 ## 🧹 Clean Backup Files
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,7 +17,11 @@ The `awtarchy` command owns command updates, config updates, config resets, revi
 
 ### Existing-install detection
 
-When `awtarchy-install.sh` detects an existing `~/.local/bin/awtarchy`, it prints the new maintenance commands and exits without rerunning the installer.
+When `awtarchy-install.sh` detects the installed `~/.local/bin/awtarchy` command, it prints the maintenance commands and exits without rerunning the installer.
+
+When it detects a legacy Awtarchy installation without the command, it performs a command-only migration. It installs the command, internal runtime, and version state without reinstalling packages or replacing managed configs.
+
+Legacy detection uses Awtarchy state, the previous cache version stamp, the managed-package manifest, or a matching set of Awtarchy-managed shell and Hyprland files.
 
 An intentional complete reinstall remains available with:
 
@@ -49,7 +53,7 @@ git pull --ff-only
 sudo ./awtarchy-install.sh
 ```
 
-Legacy installations without `~/.local/bin/awtarchy` are allowed through this migration. Afterward, future maintenance starts with `awtarchy` and no repository directory is required.
+The installer detects the legacy installation and performs only the command migration. Afterward, future maintenance starts with `awtarchy` and no repository directory is required.
 
 Persistent version state is stored under:
 

--- a/awtarchy-install.sh
+++ b/awtarchy-install.sh
@@ -8,10 +8,12 @@ IFS=$'\n\t'
 umask 022
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-RUNTIME="${SCRIPT_DIR}/local/share/awtarchy/awtarchy-runtime.sh"
+RUNTIME_SOURCE="${SCRIPT_DIR}/local/share/awtarchy/awtarchy-runtime.sh"
+LAUNCHER_SOURCE="${SCRIPT_DIR}/local/bin/awtarchy"
 TARGET_USER=""
 TARGET_HOME=""
 REINSTALL=0
+DRY_RUN_REQUESTED=0
 ARGS=()
 
 usage() {
@@ -26,8 +28,11 @@ Usage:
 This script only installs Awtarchy. After installation, use the `awtarchy`
 command for updates, config resets, review mode, version checks, and backup cleanup.
 
+Existing legacy installations are migrated to the new command without rerunning
+package installation or replacing managed configs.
+
 Options:
-  --reinstall    Run the full installer even when the installed command exists
+  --reinstall    Run the complete installer even when Awtarchy is already installed
 EOF
 }
 
@@ -50,6 +55,112 @@ resolve_target() {
   }
 }
 
+state_value() {
+  local key="$1" file="$2"
+  [[ -r $file ]] || return 1
+  sed -n "s/^${key}=//p" "$file" | head -n1
+}
+
+installed_command_exists() {
+  [[ -x "${TARGET_HOME}/.local/bin/awtarchy" \
+    && -f "${TARGET_HOME}/.local/share/awtarchy/awtarchy-runtime.sh" ]]
+}
+
+legacy_install_exists() {
+  [[ -f "${TARGET_HOME}/.cache/awtarchy/version" ]] && return 0
+  [[ -d "${TARGET_HOME}/.local/state/awtarchy/baseline" ]] && return 0
+  [[ -f "${TARGET_HOME}/.local/state/awtarchy/hardware-state" ]] && return 0
+  [[ -f /var/lib/awtarchy/managed-packages ]] && return 0
+
+  if [[ -f "${TARGET_HOME}/.bashrc" \
+    && -f "${TARGET_HOME}/.config/hypr/hyprland.lua" \
+    && -f "${TARGET_HOME}/.config/waybar/config" ]] \
+    && grep -Fq 'github.com/dillacorn/awtarchy' "${TARGET_HOME}/.bashrc";
+  then
+    return 0
+  fi
+
+  return 1
+}
+
+source_release_tag() {
+  local source_name="${SCRIPT_DIR##*/}" tag=""
+
+  if [[ -n ${AWTARCHY_INSTALL_TAG:-} ]]; then
+    printf '%s\n' "$AWTARCHY_INSTALL_TAG"
+    return 0
+  fi
+
+  if [[ $source_name == awtarchy-* ]]; then
+    tag="${source_name#awtarchy-}"
+    [[ -n $tag ]] && {
+      printf '%s\n' "$tag"
+      return 0
+    }
+  fi
+
+  if command -v git >/dev/null 2>&1 \
+    && git -C "$SCRIPT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1;
+  then
+    tag="$(git -C "$SCRIPT_DIR" tag --points-at HEAD 2>/dev/null \
+      | grep -E '^v[0-9]+([.][0-9]+)*([._+-].*)?$' \
+      | head -n1 || true)"
+    [[ -n $tag ]] && {
+      printf '%s\n' "$tag"
+      return 0
+    }
+  fi
+
+  printf '%s\n' unreleased
+}
+
+source_revision() {
+  if command -v git >/dev/null 2>&1 \
+    && git -C "$SCRIPT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1;
+  then
+    git -C "$SCRIPT_DIR" rev-parse HEAD 2>/dev/null || true
+    return 0
+  fi
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$RUNTIME_SOURCE" | awk '{print $1}'
+  fi
+}
+
+legacy_config_tag() {
+  local tag="" file=""
+  for file in \
+    "${TARGET_HOME}/.local/state/awtarchy/config-version" \
+    "${TARGET_HOME}/.local/state/awtarchy/baseline/metadata" \
+    "${TARGET_HOME}/.cache/awtarchy/version"
+  do
+    tag="$(state_value tag "$file" 2>/dev/null || true)"
+    [[ -n $tag ]] && {
+      printf '%s\n' "$tag"
+      return 0
+    }
+  done
+  printf '%s\n' unknown
+}
+
+write_version_file() {
+  local destination="$1" tag="$2" revision="${3:-}" timestamp_key="$4"
+  {
+    printf 'tag=%s\n' "$tag"
+    [[ -n $revision ]] && printf 'revision=%s\n' "$revision"
+    printf '%s=%s\n' "$timestamp_key" "$(date -Iseconds)"
+  } >"$destination"
+  chmod 0644 "$destination"
+}
+
+repair_target_ownership() {
+  [[ ${EUID} -eq 0 ]] || return 0
+  chown -R "${TARGET_USER}:${TARGET_USER}" \
+    "${TARGET_HOME}/.local/bin" \
+    "${TARGET_HOME}/.local/share/awtarchy" \
+    "${TARGET_HOME}/.local/state/awtarchy"
+}
+
 show_existing_install_message() {
   cat <<EOF
 Awtarchy is already installed for ${TARGET_USER}.
@@ -68,8 +179,76 @@ To intentionally run the complete installer again:
 EOF
 }
 
-[[ -f "$RUNTIME" ]] || {
-  printf 'ERROR: Missing installer runtime: %s\n' "$RUNTIME" >&2
+show_legacy_dry_run_message() {
+  cat <<EOF
+An existing legacy Awtarchy installation was detected for ${TARGET_USER}.
+
+No files were changed because --dry-run was used. Run this once to install the
+new maintenance command without changing packages or managed configs:
+
+  sudo ./awtarchy-install.sh
+
+Future updates will then use:
+
+  awtarchy
+EOF
+}
+
+migrate_legacy_install() {
+  local bin_dir="${TARGET_HOME}/.local/bin"
+  local data_dir="${TARGET_HOME}/.local/share/awtarchy"
+  local state_dir="${TARGET_HOME}/.local/state/awtarchy"
+  local command_version="${state_dir}/command-version"
+  local config_version="${state_dir}/config-version"
+  local command_tag config_tag revision
+
+  bash -n "$RUNTIME_SOURCE" || {
+    printf 'ERROR: Awtarchy runtime failed Bash syntax validation.\n' >&2
+    exit 1
+  }
+  bash -n "$LAUNCHER_SOURCE" || {
+    printf 'ERROR: Awtarchy command failed Bash syntax validation.\n' >&2
+    exit 1
+  }
+
+  install -d -m 0755 "$bin_dir" "$data_dir" "$state_dir"
+  install -m 0755 "$LAUNCHER_SOURCE" "${bin_dir}/awtarchy"
+  install -m 0755 "$RUNTIME_SOURCE" "${data_dir}/awtarchy-runtime.sh"
+
+  command_tag="$(source_release_tag)"
+  revision="$(source_revision)"
+  write_version_file "$command_version" "$command_tag" "$revision" installed_at
+
+  if [[ ! -f $config_version ]]; then
+    config_tag="$(legacy_config_tag)"
+    write_version_file "$config_version" "$config_tag" "" migrated_at
+  fi
+
+  repair_target_ownership
+
+  cat <<EOF
+Existing legacy Awtarchy installation detected for ${TARGET_USER}.
+
+Installed the new maintenance command:
+
+  ${bin_dir}/awtarchy
+
+No packages or managed configs were changed. Future maintenance now uses:
+
+  awtarchy                 Open the maintenance menu
+  awtarchy self-update     Update the Awtarchy command
+  awtarchy update          Update configs and preserve personal changes
+  awtarchy reset           Reset managed configs to release defaults
+  awtarchy version         Show installed and latest releases
+EOF
+}
+
+[[ -f $RUNTIME_SOURCE ]] || {
+  printf 'ERROR: Missing installer runtime: %s\n' "$RUNTIME_SOURCE" >&2
+  exit 1
+}
+[[ -f $LAUNCHER_SOURCE ]] || {
+  printf 'ERROR: Missing maintenance command: %s\n' "$LAUNCHER_SOURCE" >&2
   exit 1
 }
 
@@ -86,6 +265,11 @@ while (( $# )); do
       REINSTALL=1
       shift
       ;;
+    --dry-run|--test)
+      DRY_RUN_REQUESTED=1
+      ARGS+=("$1")
+      shift
+      ;;
     update|reset|review|clean-backups|version|check-update|self-update|update-reset-backup|update-backup-cleaner)
       printf 'ERROR: %s is a maintenance command. Run it through: awtarchy %s\n' "$1" "$1" >&2
       exit 2
@@ -99,9 +283,20 @@ done
 
 resolve_target
 
-if (( REINSTALL == 0 )) && [[ -x "${TARGET_HOME}/.local/bin/awtarchy" ]]; then
-  show_existing_install_message
-  exit 0
+if (( REINSTALL == 0 )); then
+  if installed_command_exists; then
+    show_existing_install_message
+    exit 0
+  fi
+
+  if legacy_install_exists; then
+    if (( DRY_RUN_REQUESTED == 1 )); then
+      show_legacy_dry_run_message
+    else
+      migrate_legacy_install
+    fi
+    exit 0
+  fi
 fi
 
-exec env AWTARCHY_REPO_DIR="$SCRIPT_DIR" bash "$RUNTIME" install "${ARGS[@]}"
+exec env AWTARCHY_REPO_DIR="$SCRIPT_DIR" bash "$RUNTIME_SOURCE" install "${ARGS[@]}"

--- a/tests/test-awtarchy-command.sh
+++ b/tests/test-awtarchy-command.sh
@@ -123,6 +123,37 @@ grep -Fq 'Awtarchy is already installed' <<<"$existing_output" \
 grep -Fq 'awtarchy self-update' <<<"$existing_output" \
   || fail "installer did not explain the new update command"
 
+legacy_home="${TMP}/legacy-home"
+mkdir -p "$legacy_home/.cache/awtarchy"
+printf 'tag=v0.8.0\nupdated_at=2000-01-01T00:00:00Z\n' \
+  >"$legacy_home/.cache/awtarchy/version"
+legacy_output="$(
+  HOME="$legacy_home" USER="$(id -un)" AWTARCHY_INSTALL_TAG=v9.9.9 \
+    bash "$INSTALLER_SOURCE"
+)"
+assert_executable "$legacy_home/.local/bin/awtarchy"
+assert_executable "$legacy_home/.local/share/awtarchy/awtarchy-runtime.sh"
+grep -Fxq 'tag=v9.9.9' "$legacy_home/.local/state/awtarchy/command-version" \
+  || fail "legacy migration did not record the command release"
+grep -Fxq 'tag=v0.8.0' "$legacy_home/.local/state/awtarchy/config-version" \
+  || fail "legacy migration did not preserve the prior config release"
+grep -Fq 'No packages or managed configs were changed' <<<"$legacy_output" \
+  || fail "legacy migration did not explain its safe scope"
+[[ ! -d "$legacy_home/.config" ]] \
+  || fail "legacy migration unexpectedly created managed config files"
+
+legacy_dry_home="${TMP}/legacy-dry-home"
+mkdir -p "$legacy_dry_home/.cache/awtarchy"
+printf 'tag=v0.8.0\n' >"$legacy_dry_home/.cache/awtarchy/version"
+legacy_dry_output="$(
+  HOME="$legacy_dry_home" USER="$(id -un)" \
+    bash "$INSTALLER_SOURCE" --dry-run
+)"
+[[ ! -e "$legacy_dry_home/.local/bin/awtarchy" ]] \
+  || fail "legacy dry-run installed the maintenance command"
+grep -Fq 'No files were changed because --dry-run was used' <<<"$legacy_dry_output" \
+  || fail "legacy dry-run did not explain the migration"
+
 set +e
 maintenance_output="$(HOME="$home" USER="$(id -un)" bash "$INSTALLER_SOURCE" update 2>&1)"
 maintenance_rc=$?


### PR DESCRIPTION
## Summary

- detect legacy Awtarchy installations that predate the installed `awtarchy` command
- install only the maintenance command, internal runtime, and persistent version state
- preserve the previous config release tag when available
- avoid package installation and managed-config replacement during migration
- keep `--reinstall` as the explicit path to the full installer
- make legacy `--dry-run` report the migration without changing files
- expand integration coverage for live and dry-run legacy migration

## Validation

Passed on head `3776ad31a7a41cf6b1136fec8127db2012f0b2ff`:

- Bash syntax
- ShellCheck command code
- installed-command detection
- live legacy command-only migration
- preservation of the previous config release tag
- verification that migration creates no managed `.config` files
- legacy dry-run with no filesystem changes
- command self-update and config-update integration tests
- existing Waybar event-driven and ddcutil checks

No manual test is required before merge.