### PR TITLE
Limit legacy migration ownership changes

### DIFF
--- a/awtarchy-install.sh
+++ b/awtarchy-install.sh
@@ -155,10 +155,20 @@ write_version_file() {
 
 repair_target_ownership() {
   [[ ${EUID} -eq 0 ]] || return 0
-  chown -R "${TARGET_USER}:${TARGET_USER}" \
+
+  local path
+  for path in \
     "${TARGET_HOME}/.local/bin" \
+    "${TARGET_HOME}/.local/bin/awtarchy" \
     "${TARGET_HOME}/.local/share/awtarchy" \
-    "${TARGET_HOME}/.local/state/awtarchy"
+    "${TARGET_HOME}/.local/share/awtarchy/awtarchy-runtime.sh" \
+    "${TARGET_HOME}/.local/state/awtarchy" \
+    "${TARGET_HOME}/.local/state/awtarchy/command-version" \
+    "${TARGET_HOME}/.local/state/awtarchy/config-version"
+  do
+    [[ -e $path || -L $path ]] || continue
+    chown -h "${TARGET_USER}:${TARGET_USER}" "$path"
+  done
 }
 
 show_existing_install_message() {


### PR DESCRIPTION
## Summary

- stop recursively changing ownership across all of `~/.local/bin`
- restrict ownership repair to Awtarchy directories and the exact command/runtime/version files created by migration
- preserve unrelated user-local executables and files

## Validation

Bash syntax, ShellCheck, command integration tests, and existing Waybar checks must pass before merge.