### PR TITLE
Fix managed awtwall desktop entry

### DIFF
--- a/.github/workflows/validate-awtarchy.yml
+++ b/.github/workflows/validate-awtarchy.yml
@@ -15,26 +15,31 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install validation tools
-        run: sudo apt-get update && sudo apt-get install -y shellcheck lua5.4
+        run: sudo apt-get update && sudo apt-get install -y desktop-file-utils shellcheck lua5.4
       - name: Bash syntax
         run: |
           test ! -e awtarchy.sh
           bash -n awtarchy-install.sh
           bash -n local/bin/awtarchy
           bash -n local/share/awtarchy/awtarchy-runtime.sh
+          bash -n config/hypr/scripts/awtwall_launcher.sh
           bash -n tests/test-awtarchy-command.sh
           bash -n tests/test-awtarchy-command-shim.sh
+          bash -n tests/test-desktop-files.sh
           bash -n tests/test-lua-validation.sh
       - name: ShellCheck command code
         run: |
           shellcheck \
             awtarchy-install.sh \
             local/bin/awtarchy \
+            config/hypr/scripts/awtwall_launcher.sh \
             tests/test-awtarchy-command.sh \
             tests/test-awtarchy-command-shim.sh \
+            tests/test-desktop-files.sh \
             tests/test-lua-validation.sh
       - name: Command and updater integration tests
         run: |
           bash tests/test-awtarchy-command.sh
           bash tests/test-awtarchy-command-shim.sh
+          bash tests/test-desktop-files.sh
           bash tests/test-lua-validation.sh

--- a/.github/workflows/validate-awtarchy.yml
+++ b/.github/workflows/validate-awtarchy.yml
@@ -37,9 +37,10 @@ jobs:
             tests/test-awtarchy-command-shim.sh \
             tests/test-desktop-files.sh \
             tests/test-lua-validation.sh
+      - name: Managed desktop entries
+        run: bash tests/test-desktop-files.sh
       - name: Command and updater integration tests
         run: |
           bash tests/test-awtarchy-command.sh
           bash tests/test-awtarchy-command-shim.sh
-          bash tests/test-desktop-files.sh
           bash tests/test-lua-validation.sh

--- a/config/hypr/scripts/awtwall_launcher.sh
+++ b/config/hypr/scripts/awtwall_launcher.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# github.com/dillacorn/awtarchy/tree/main/config/hypr/scripts
+# ~/.config/hypr/scripts/awtwall_launcher.sh
+
+set -euo pipefail
+
+notify_error() {
+    local message="$1"
+
+    if command -v hyprctl >/dev/null 2>&1; then
+        hyprctl notify 3 5000 "rgb(ff5555)" "$message" >/dev/null 2>&1 || true
+    else
+        printf 'awtwall: %s\n' "$message" >&2
+    fi
+}
+
+if ! command -v awtwall >/dev/null 2>&1; then
+    notify_error "awtwall is not installed."
+    exit 127
+fi
+
+launch_handler="$HOME/.config/hypr/scripts/launch_handler.sh"
+if [[ ! -x "$launch_handler" ]]; then
+    notify_error "Awtarchy launch handler is missing."
+    exit 127
+fi
+
+exec "$launch_handler" \
+    wallpicker \
+    "alacritty --class wallpicker -e awtwall --resume"

--- a/local/share/applications/awtwall.desktop
+++ b/local/share/applications/awtwall.desktop
@@ -9,6 +9,6 @@ Comment=Browse and apply wallpapers
 Keywords=wallpaper;picker;awtwall;background;
 Icon=utilities-terminal
 Terminal=false
-Exec=/bin/sh -c 'if command -v awtwall >/dev/null 2>&1; then exec "$HOME/.config/hypr/scripts/launch_handler.sh" wallpicker "alacritty --class wallpicker -e awtwall --resume"; else hyprctl notify 3 5000 "rgb(ff5555)" "awtwall is not installed."; fi'
+Exec=/bin/sh -c "exec ~/.config/hypr/scripts/awtwall_launcher.sh"
 Categories=Utility;Settings;
 StartupNotify=false

--- a/tests/test-desktop-files.sh
+++ b/tests/test-desktop-files.sh
@@ -40,8 +40,14 @@ mapfile -d '' desktop_files < <(
 (( ${#desktop_files[@]} > 0 )) \
     || fail "no managed desktop entries were found"
 
+validation_failed=0
 for desktop_file in "${desktop_files[@]}"; do
-    desktop-file-validate "$desktop_file"
+    if ! desktop-file-validate "$desktop_file"; then
+        validation_failed=1
+    fi
 done
+
+(( validation_failed == 0 )) \
+    || fail "one or more managed desktop entries failed validation"
 
 printf 'Managed desktop-entry tests passed.\n'

--- a/tests/test-desktop-files.sh
+++ b/tests/test-desktop-files.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+APPLICATIONS_DIR="${ROOT}/local/share/applications"
+AWTWALL_DESKTOP="${APPLICATIONS_DIR}/awtwall.desktop"
+AWTWALL_LAUNCHER="${ROOT}/config/hypr/scripts/awtwall_launcher.sh"
+
+fail() {
+    printf 'FAIL: %s\n' "$*" >&2
+    exit 1
+}
+
+command -v desktop-file-validate >/dev/null 2>&1 \
+    || fail "desktop-file-validate is required for this test"
+
+[[ -d "$APPLICATIONS_DIR" ]] \
+    || fail "managed desktop-entry directory is missing"
+[[ -f "$AWTWALL_DESKTOP" ]] \
+    || fail "awtwall desktop entry is missing"
+[[ -f "$AWTWALL_LAUNCHER" ]] \
+    || fail "awtwall launcher is missing"
+
+bash -n "$AWTWALL_LAUNCHER"
+
+grep -Fxq 'Exec=/bin/sh -c "exec ~/.config/hypr/scripts/awtwall_launcher.sh"' \
+    "$AWTWALL_DESKTOP" \
+    || fail "awtwall desktop entry does not use the managed launcher"
+
+grep -Fq 'exec "$launch_handler"' "$AWTWALL_LAUNCHER" \
+    || fail "awtwall launcher does not preserve launch_handler behavior"
+grep -Fq 'alacritty --class wallpicker -e awtwall --resume' "$AWTWALL_LAUNCHER" \
+    || fail "awtwall launcher does not preserve the wallpicker command"
+
+mapfile -d '' desktop_files < <(
+    find "$APPLICATIONS_DIR" -type f -name '*.desktop' -print0 | sort -z
+)
+(( ${#desktop_files[@]} > 0 )) \
+    || fail "no managed desktop entries were found"
+
+for desktop_file in "${desktop_files[@]}"; do
+    desktop-file-validate "$desktop_file"
+done
+
+printf 'Managed desktop-entry tests passed.\n'

--- a/tests/test-desktop-files.sh
+++ b/tests/test-desktop-files.sh
@@ -28,6 +28,7 @@ grep -Fxq 'Exec=/bin/sh -c "exec ~/.config/hypr/scripts/awtwall_launcher.sh"' \
     "$AWTWALL_DESKTOP" \
     || fail "awtwall desktop entry does not use the managed launcher"
 
+# shellcheck disable=SC2016
 grep -Fq 'exec "$launch_handler"' "$AWTWALL_LAUNCHER" \
     || fail "awtwall launcher does not preserve launch_handler behavior"
 grep -Fq 'alacritty --class wallpicker -e awtwall --resume' "$AWTWALL_LAUNCHER" \


### PR DESCRIPTION
Closed without merging. The audit showed that many intentional Awtarchy desktop launchers use shell-based Exec values that work in the target environment but are rejected by desktop-file-validate. The correct updater fix is to avoid treating that strict compatibility check as fatal while preserving the existing working Hyprland and desktop launcher behavior.