### PR TITLE
Trigger v3.2.2 release

### DIFF
--- a/.github/release-v3.2.2-notes.md
+++ b/.github/release-v3.2.2-notes.md
@@ -1,0 +1,69 @@
+# Awtarchy v3.2.2 Quickshell
+
+Awtarchy v3.2.2 adds quiet, actionable update notifications to the normal Quickshell notification experience. It clearly separates new stable releases from meaningful same-release maintenance refreshes while avoiding repeat alerts.
+
+## Getting started
+
+Awtarchy is an Arch Linux overlay/environment, not a Linux distribution or an Arch Linux installer. Install it onto a working minimal Arch Linux system.
+
+If you are starting from zero:
+
+1. Download the official Arch Linux ISO from the [Arch Linux download page](https://archlinux.org/download/).
+2. Boot the Arch Linux ISO.
+3. Install a working minimal Arch Linux system first.
+   - For most users, Awtarchy recommends the official `archinstall` guided installer included with the Arch ISO as the easiest path. Run `archinstall` from the live environment and complete a minimal Arch installation.
+   - A normal manual Arch installation using the [ArchWiki Installation Guide](https://wiki.archlinux.org/title/Installation_guide) is also fine.
+4. Boot into the installed Arch system.
+
+Once you have a working minimal Arch installation, install Awtarchy:
+
+```bash
+sudo pacman -S git --noconfirm
+git clone https://github.com/dillacorn/awtarchy
+cd awtarchy
+sudo ./awtarchy-install.sh
+```
+
+Existing Awtarchy users:
+
+```bash
+awtarchy update
+```
+
+## Stable update notifications
+
+- Awtarchy now checks for newer published stable releases and notifies through its normal Quickshell notification server and history.
+- The notice clearly shows the installed and target versions, such as `v3.2.1 → v3.2.2`, and reminds users that they can run `awtarchy update`.
+- Draft releases, prereleases, unknown or unreleased installs, and Git-testing state do not generate normal stable-release notices.
+- A GitHub icon identifies the update source, with visible **Update ↑** and **Release Notes ↗** actions.
+- **Release Notes ↗** opens the exact GitHub release page without dismissing the notification or disabling its remaining update action.
+- **Update ↑** opens Awtarchy's existing terminal helper and starts the updater. The notice closes only when the command succeeds and the installed config reaches the advertised release or a newer one.
+
+## Calm by default
+
+- Stable targets are remembered across sessions, so the same update is not announced again at every login.
+- Update notices can be disabled from the Notifications cog-wheel settings.
+- When notices are disabled, checks are reduced to weekly. Only a proven gap of five or more stable releases may produce an occasional normal-urgency catch-up notice, with a 30-day cooldown across targets.
+- Network failures remain silent and checks are rate-limited.
+
+## Same-release maintenance refreshes
+
+- Awtarchy can distinguish a stable config release from a newer maintenance command/runtime on `main` without pretending that the version string changed.
+- A maintenance notice appears only when `command-version` is behind `main` and the installed launcher or runtime payload actually differs from the corresponding Git blob on `main`.
+- Meaningful same-release fixes are labeled **Awtarchy Maintenance Refresh** and use `awtarchy self-update`; commit-only changes with identical installed payloads stay silent.
+- Maintenance notices do not show a misleading stable-release notes action.
+
+## Notification and terminal polish
+
+- Update actions use a clean non-login shell, avoiding Fastfetch and other login-profile output.
+- Held terminal commands now report the real exit status without the prior stray `status=0` text.
+- The update-notification setting and popup controls use a cleaner Notifications layout.
+
+## Validation
+
+- Added focused integration coverage for stable, prerelease, Git-testing, offline, suppression, catch-up, deduplication, resident actions, successful and failed updates, newer-target races, and maintenance payload identity.
+- Bash syntax, ShellCheck, desktop validation, command/updater integration, Quickshell production-readiness, managed-history migration, anonymous failure-reporting, anti-spam, and the complete repository workflow passed before release.
+
+## Post-release updates
+
+_Placeholder for possible tested post-release patches to v3.2.2._

--- a/.github/workflows/validate-awtarchy.yml
+++ b/.github/workflows/validate-awtarchy.yml
@@ -258,8 +258,8 @@ jobs:
           bash tests/test-quickshell-resume-recovery.sh
           bash tests/test-quickshell-updater-bootstrap.sh
 
-  publish-v3-2-2:
-    name: Publish and verify v3.2.2
+  verify-v3-2-2:
+    name: Verify v3.2.2 and remove one-use bridge
     needs: validate
     if: github.event_name == 'pull_request' && github.event.pull_request.title == 'Trigger v3.2.2 release' && github.event.pull_request.head.ref == 'v3-2-2-release-trigger' && github.event.pull_request.base.ref == 'main'
     permissions:
@@ -267,12 +267,12 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - name: Check out guarded release bridge
+      - name: Check out guarded verification bridge
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           fetch-depth: 0
 
-      - name: Publish, verify, and remove the one-use bridge
+      - name: Verify the published release and remove the one-use bridge
         env:
           GH_TOKEN: ${{ github.token }}
           TARGET_SHA: 8fffb63c431854aded9d862c58737ca1395ffb12
@@ -300,32 +300,7 @@ jobs:
             and .isPrerelease == false
           ' previous-release.json >/dev/null
 
-          if git ls-remote --exit-code --tags origin "refs/tags/${RELEASE_TAG}" >/dev/null 2>&1; then
-            echo "${RELEASE_TAG} tag already exists; refusing to recreate it." >&2
-            false
-          fi
-
-          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            echo "${RELEASE_TAG} release already exists; refusing to replace it." >&2
-            false
-          fi
-
-          grep -Fq "# Awtarchy v3.2.2 Quickshell" "$NOTES_FILE"
-          grep -Fq "## Getting started" "$NOTES_FILE"
-          grep -Fq "sudo ./awtarchy-install.sh" "$NOTES_FILE"
-          grep -Fq "awtarchy update" "$NOTES_FILE"
-          grep -Fq "## Stable update notifications" "$NOTES_FILE"
-          grep -Fq "## Same-release maintenance refreshes" "$NOTES_FILE"
-
-          gh release create "$RELEASE_TAG" \
-            --repo "$GITHUB_REPOSITORY" \
-            --target "$TARGET_SHA" \
-            --title "$RELEASE_NAME" \
-            --latest \
-            --notes-file "$NOTES_FILE"
-
           test "$(git ls-remote origin "refs/tags/${RELEASE_TAG}" | awk '{print $1}')" = "$TARGET_SHA"
-
           gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
             --json name,targetCommitish,isDraft,isPrerelease,body,url >verified-release.json
           jq -e --arg target "$TARGET_SHA" --arg name "$RELEASE_NAME" '
@@ -334,7 +309,7 @@ jobs:
             and .isDraft == false
             and .isPrerelease == false
           ' verified-release.json >/dev/null
-          jq -r '.body' verified-release.json >verified-release.md
+          jq -j '.body' verified-release.json >verified-release.md
           cmp --silent "$NOTES_FILE" verified-release.md
           test "$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)" = "$RELEASE_TAG"
           release_url="$(jq -r '.url' verified-release.json)"
@@ -342,4 +317,4 @@ jobs:
           gh pr close "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --delete-branch \
             --comment "${RELEASE_TAG} published and verified: ${release_url}"
 
-          printf "Published and verified %s at %s\n" "$RELEASE_TAG" "$release_url"
+          printf "Verified %s at %s and removed the one-use bridge\n" "$RELEASE_TAG" "$release_url"

--- a/.github/workflows/validate-awtarchy.yml
+++ b/.github/workflows/validate-awtarchy.yml
@@ -257,3 +257,89 @@ jobs:
           bash tests/test-usb-refresh-security.sh
           bash tests/test-quickshell-resume-recovery.sh
           bash tests/test-quickshell-updater-bootstrap.sh
+
+  publish-v3-2-2:
+    name: Publish and verify v3.2.2
+    needs: validate
+    if: github.event_name == 'pull_request' && github.event.pull_request.title == 'Trigger v3.2.2 release' && github.event.pull_request.head.ref == 'v3-2-2-release-trigger' && github.event.pull_request.base.ref == 'main'
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out guarded release bridge
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          fetch-depth: 0
+
+      - name: Publish, verify, and remove the one-use bridge
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_SHA: 8fffb63c431854aded9d862c58737ca1395ffb12
+          TARGET_TREE: 7da930cc641540d2d9c2705a8a93623083ab32f1
+          PREVIOUS_TAG_SHA: d51e7dcab8d87ce4cc8bdd77f9d12a2e275150ee
+          RELEASE_TAG: v3.2.2
+          RELEASE_NAME: Awtarchy v3.2.2 Quickshell
+          NOTES_FILE: .github/release-v3.2.2-notes.md
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          test "$(git rev-parse "${TARGET_SHA}^{tree}")" = "$TARGET_TREE"
+          git merge-base --is-ancestor "$TARGET_SHA" HEAD
+          git diff --quiet "$TARGET_SHA" HEAD -- . \
+            ':(exclude).github/workflows/validate-awtarchy.yml' \
+            ':(exclude).github/release-v3.2.2-notes.md'
+
+          test "$(git ls-remote origin refs/tags/v3.2.1 | awk '{print $1}')" = "$PREVIOUS_TAG_SHA"
+          gh release view v3.2.1 --repo "$GITHUB_REPOSITORY" --json name,targetCommitish,isDraft,isPrerelease >previous-release.json
+          jq -e --arg target "$PREVIOUS_TAG_SHA" '
+            .name == "Awtarchy v3.2.1 Quickshell"
+            and .targetCommitish == $target
+            and .isDraft == false
+            and .isPrerelease == false
+          ' previous-release.json >/dev/null
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${RELEASE_TAG}" >/dev/null 2>&1; then
+            echo "${RELEASE_TAG} tag already exists; refusing to recreate it." >&2
+            false
+          fi
+
+          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "${RELEASE_TAG} release already exists; refusing to replace it." >&2
+            false
+          fi
+
+          grep -Fq "# Awtarchy v3.2.2 Quickshell" "$NOTES_FILE"
+          grep -Fq "## Getting started" "$NOTES_FILE"
+          grep -Fq "sudo ./awtarchy-install.sh" "$NOTES_FILE"
+          grep -Fq "awtarchy update" "$NOTES_FILE"
+          grep -Fq "## Stable update notifications" "$NOTES_FILE"
+          grep -Fq "## Same-release maintenance refreshes" "$NOTES_FILE"
+
+          gh release create "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$TARGET_SHA" \
+            --title "$RELEASE_NAME" \
+            --latest \
+            --notes-file "$NOTES_FILE"
+
+          test "$(git ls-remote origin "refs/tags/${RELEASE_TAG}" | awk '{print $1}')" = "$TARGET_SHA"
+
+          gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
+            --json name,targetCommitish,isDraft,isPrerelease,body,url >verified-release.json
+          jq -e --arg target "$TARGET_SHA" --arg name "$RELEASE_NAME" '
+            .name == $name
+            and .targetCommitish == $target
+            and .isDraft == false
+            and .isPrerelease == false
+          ' verified-release.json >/dev/null
+          jq -r '.body' verified-release.json >verified-release.md
+          cmp --silent "$NOTES_FILE" verified-release.md
+          test "$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)" = "$RELEASE_TAG"
+          release_url="$(jq -r '.url' verified-release.json)"
+
+          gh pr close "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --delete-branch \
+            --comment "${RELEASE_TAG} published and verified: ${release_url}"
+
+          printf "Published and verified %s at %s\n" "$RELEASE_TAG" "$release_url"


### PR DESCRIPTION
One-use, exact-head GitHub Actions bridge to publish and verify the stable `v3.2.2` release at main commit `8fffb63c431854aded9d862c58737ca1395ffb12` after the existing validation job passes. The job verifies `v3.2.1` remains unchanged, refuses to replace any existing `v3.2.2` tag/release, compares the complete published body to the checked-in temporary notes, and closes/deletes this helper PR branch after success.