### PR TITLE
Trigger v3.3.0 release

### DIFF
--- a/.github/release-v3.3.0-notes.md
+++ b/.github/release-v3.3.0-notes.md
@@ -1,0 +1,67 @@
+# Awtarchy v3.3.0 Quickshell
+
+Awtarchy v3.3.0 replaces the GNOME PolicyKit authentication agent with an Awtarchy-owned terminal authentication flow. The trusted authentication backend stays headless while idle and opens a transient Alacritty TUI only when authorization is actually required.
+
+## Getting started
+
+Awtarchy is an Arch Linux overlay/environment, not a Linux distribution or an Arch Linux installer. Install it onto a working minimal Arch Linux system.
+
+If you are starting from zero:
+
+1. Download the official Arch Linux ISO from the [Arch Linux download page](https://archlinux.org/download/).
+2. Boot the Arch Linux ISO.
+3. Install a working minimal Arch Linux system first.
+   - For most users, Awtarchy recommends the official `archinstall` guided installer included with the Arch ISO as the easiest path. Run `archinstall` from the live environment and complete a minimal Arch installation.
+   - A normal manual Arch installation using the [ArchWiki Installation Guide](https://wiki.archlinux.org/title/Installation_guide) is also fine.
+4. Boot into the installed Arch system.
+
+Once you have a working minimal Arch installation, install Awtarchy:
+
+```bash
+sudo pacman -S git --noconfirm
+git clone https://github.com/dillacorn/awtarchy
+cd awtarchy
+sudo ./awtarchy-install.sh
+```
+
+Existing Awtarchy users:
+
+```bash
+awtarchy update
+```
+
+## Awtarchy terminal PolicyKit authentication
+
+- Replaces `polkit-gnome` with an Awtarchy-owned PolicyKit authentication agent.
+- Keeps the trusted Python authentication backend headless while idle instead of parking a hidden authentication window on a special workspace.
+- Opens a transient real Alacritty terminal only while an authentication request is active.
+- Uses the current sanitized Alacritty appearance without loading arbitrary user terminal commands, key bindings, environment settings, or plugins into the trusted authentication runtime.
+- Supports keyboard and mouse controls, clear password retry feedback, and an animated `Authenticating` status while PAM/PolicyKit is processing.
+- Successful authentication closes immediately without adding an artificial delay.
+
+## Credential and runtime security
+
+- The backend and terminal frontend communicate through an inherited anonymous `AF_UNIX`/`SOCK_SEQPACKET` socketpair instead of a filesystem IPC path.
+- Passwords travel only from the terminal frontend into `PolkitAgent.Session.response()` and are not persisted, logged, stored in temporary files, placed in command-line arguments or environment variables, or passed through `sudo -S`.
+- The installed authentication runtime is root-owned under `/usr/local/libexec/awtarchy/polkit-agent` with a dedicated user service under `/usr/local/lib/systemd/user/awtarchy-polkit-agent.service`.
+- Runtime startup validates ownership, file types and modes, Python/PyGObject/PolicyKit prerequisites, and the graphical login session before activation.
+- Agent diagnostics are sent to the journal rather than leaking warnings or tracebacks into the authentication terminal.
+
+## Migration and rollback safety
+
+- `polkit` and `python-gobject` are explicit installation/update dependencies.
+- The PolicyKit runtime is installed through a staged root-owned transaction and verified before it becomes active.
+- If the privileged PolicyKit runtime installation fails during an update, Awtarchy's user-file transaction is rolled back instead of leaving a partially migrated desktop configuration.
+- Existing `polkit-gnome` is retained as a controlled fallback while activation of the new agent is being validated.
+- Removal of `polkit-gnome` is delayed and ownership-gated rather than happening before the replacement agent is proven live.
+
+## Validation
+
+- End-to-end authorization was live-tested with the installed root-owned runtime using both `pkexec` and a real systemd-generated PolicyKit request.
+- Password retries, successful authorization, terminal theming, transient-window behavior, and authentication feedback were live-tested on the desktop.
+- Permanent PolicyKit CI covers TUI parsing, authentication feedback, transient frontend lifecycle, headless idle behavior, retry handling, sanitized Alacritty appearance, GLib socket watching, Hyprland integration, graphical-session binding, startup diagnostics, secure credential transport, production migration integration, and runtime rebuild behavior.
+- Bash syntax, ShellCheck, desktop validation, command/updater integration, managed-history migration, anonymous failure-reporting, and the dedicated PolicyKit suite all passed on the exact `v3.3.0` release target before publication.
+
+## Post-release updates
+
+_Placeholder for possible tested post-release patches to v3.3.0._

--- a/.github/workflows/release-v3.3.0.yml
+++ b/.github/workflows/release-v3.3.0.yml
@@ -1,0 +1,115 @@
+name: Publish Awtarchy v3.3.0
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  publish-v3-3-0:
+    name: Publish and verify v3.3.0
+    if: github.event.pull_request.title == 'Trigger v3.3.0 release' && github.event.pull_request.head.ref == 'v3-3-0-release-trigger' && github.event.pull_request.base.ref == 'main'
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out guarded release bridge
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          fetch-depth: 0
+
+      - name: Publish, verify, and remove the one-use bridge
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_SHA: 8fb4ea02c774f56787c3dc85c26f872d9f7596a5
+          TARGET_TREE: 8edfdb76e6578d0e0ef2b30a0db6bef2893e351d
+          PREVIOUS_TAG_SHA: 8fffb63c431854aded9d862c58737ca1395ffb12
+          RELEASE_TAG: v3.3.0
+          RELEASE_NAME: Awtarchy v3.3.0 Quickshell
+          NOTES_FILE: .github/release-v3.3.0-notes.md
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          test "$(git rev-parse "${TARGET_SHA}^{tree}")" = "$TARGET_TREE"
+          test "$(git rev-parse origin/main)" = "$TARGET_SHA"
+          git merge-base --is-ancestor "$TARGET_SHA" HEAD
+          git diff --quiet "$TARGET_SHA" HEAD -- . \
+            ':(exclude).github/workflows/release-v3.3.0.yml' \
+            ':(exclude).github/release-v3.3.0-notes.md'
+
+          test "$(git ls-remote origin refs/tags/v3.2.2 | awk '{print $1}')" = "$PREVIOUS_TAG_SHA"
+          gh release view v3.2.2 --repo "$GITHUB_REPOSITORY" --json name,targetCommitish,isDraft,isPrerelease >previous-release.json
+          jq -e --arg target "$PREVIOUS_TAG_SHA" '
+            .name == "Awtarchy v3.2.2 Quickshell"
+            and .targetCommitish == $target
+            and .isDraft == false
+            and .isPrerelease == false
+          ' previous-release.json >/dev/null
+
+          runs_json="$(mktemp)"
+          gh api "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${TARGET_SHA}&event=push&per_page=100" >"$runs_json"
+          for workflow in \
+            'Validate Awtarchy' \
+            'Validate PolicyKit Agent' \
+            'Validate Anonymous Failure Reporting'
+          do
+            jq -e --arg workflow "$workflow" '
+              [.workflow_runs[] | select(.name == $workflow and .head_sha == env.TARGET_SHA)]
+              | length > 0
+              and all(.[]; .status == "completed" and .conclusion == "success")
+            ' "$runs_json" >/dev/null || {
+              echo "Required main workflow is not green: ${workflow}" >&2
+              false
+            }
+          done
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${RELEASE_TAG}" >/dev/null 2>&1; then
+            echo "${RELEASE_TAG} tag already exists; refusing to recreate it." >&2
+            false
+          fi
+
+          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "${RELEASE_TAG} release already exists; refusing to replace it." >&2
+            false
+          fi
+
+          grep -Fq '# Awtarchy v3.3.0 Quickshell' "$NOTES_FILE"
+          grep -Fq '## Getting started' "$NOTES_FILE"
+          grep -Fq 'sudo ./awtarchy-install.sh' "$NOTES_FILE"
+          grep -Fq 'awtarchy update' "$NOTES_FILE"
+          grep -Fq '## Awtarchy terminal PolicyKit authentication' "$NOTES_FILE"
+          grep -Fq '## Migration and rollback safety' "$NOTES_FILE"
+          grep -Fq '## Validation' "$NOTES_FILE"
+          grep -Fq '## Post-release updates' "$NOTES_FILE"
+          grep -Fq '_Placeholder for possible tested post-release patches to v3.3.0._' "$NOTES_FILE"
+
+          gh release create "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$TARGET_SHA" \
+            --title "$RELEASE_NAME" \
+            --latest \
+            --notes-file "$NOTES_FILE"
+
+          test "$(git ls-remote origin "refs/tags/${RELEASE_TAG}" | awk '{print $1}')" = "$TARGET_SHA"
+
+          gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
+            --json name,targetCommitish,isDraft,isPrerelease,body,url >verified-release.json
+          jq -e --arg target "$TARGET_SHA" --arg name "$RELEASE_NAME" '
+            .name == $name
+            and .targetCommitish == $target
+            and .isDraft == false
+            and .isPrerelease == false
+          ' verified-release.json >/dev/null
+          jq -j '.body' verified-release.json >verified-release.md
+          cmp --silent "$NOTES_FILE" verified-release.md
+          test "$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)" = "$RELEASE_TAG"
+          release_url="$(jq -r '.url' verified-release.json)"
+
+          gh pr close "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --delete-branch \
+            --comment "${RELEASE_TAG} published and verified: ${release_url}"
+
+          printf 'Published and verified %s at %s\n' "$RELEASE_TAG" "$release_url"


### PR DESCRIPTION
One-use, exact-head GitHub Actions bridge to publish and verify the stable `v3.3.0` release at main commit `8fb4ea02c774f56787c3dc85c26f872d9f7596a5`. The bridge refuses to publish if `main` moved, if `v3.2.2` changed, if the required post-merge main workflows are not green, if any non-release-helper file differs from the release target, or if a `v3.3.0` tag/release already exists. It verifies the complete published body against the checked-in release notes and closes/deletes the helper branch after success.