### PR TITLE
Publish Awtarchy v3.3.1 release

### DIFF
--- a/.github/release-v3.3.1.md
+++ b/.github/release-v3.3.1.md
@@ -1,0 +1,56 @@
+# Awtarchy v3.3.1 Quickshell
+
+Awtarchy v3.3.1 is a focused bug-fix release for update notifications. It keeps the v3.3.0 Quickshell and terminal PolicyKit changes while fixing a login-check bug that could prevent users from being notified about a newly published Awtarchy release.
+
+## Getting started
+
+Awtarchy is an Arch Linux overlay/environment, not a Linux distribution or an Arch Linux installer. Install it onto a working minimal Arch Linux system.
+
+If you are starting from zero:
+
+1. Download the official Arch Linux ISO from the [Arch Linux download page](https://archlinux.org/download/).
+2. Boot the Arch Linux ISO.
+3. Install a working minimal Arch Linux system first.
+   - For most users, Awtarchy recommends the official `archinstall` guided installer included with the Arch ISO as the easiest path. Run `archinstall` from the live environment and complete a minimal Arch installation.
+   - A normal manual Arch installation using the [ArchWiki Installation Guide](https://wiki.archlinux.org/title/Installation_guide) is also fine.
+4. Boot into the installed Arch system.
+
+Once you have a working minimal Arch installation, install Awtarchy:
+
+```bash
+sudo pacman -S git --noconfirm
+git clone https://github.com/dillacorn/awtarchy
+cd awtarchy
+sudo ./awtarchy-install.sh
+```
+
+Existing Awtarchy users:
+
+```bash
+awtarchy update
+```
+
+## Update notification reliability
+
+- The 30-second graphical startup check now uses an explicit login mode and is no longer suppressed just because the previous periodic check happened less than six hours earlier.
+- Periodic update checks remain rate-limited to every six hours.
+- A stable release is recorded as announced only after `notify-send` returns a valid notification ID, so a failed notification attempt does not permanently consume that release notification.
+- Successful notifications still suppress duplicate alerts for the same release.
+- Git-testing mode continues to suppress stable-release notifications as intended.
+
+## v3.3.0 baseline retained
+
+- Keeps the Awtarchy-owned terminal PolicyKit authentication agent introduced in v3.3.0.
+- Keeps the headless trusted authentication backend and transient Alacritty TUI behavior.
+- Keeps the root-owned PolicyKit runtime, migration safeguards, credential-transport protections, and rollback behavior from v3.3.0.
+
+## Validation
+
+- The original bug was reproduced on a real Awtarchy laptop: a simulated login one hour after the previous check produced no notification, while the same state seven hours after the previous check did.
+- The fixed branch was live-tested on the same laptop with a temporary `v3.2.2` state and `last_check` set to the current second; login mode still displayed the expected `v3.2.2 → v3.3.0` update notification.
+- Permanent regression coverage verifies that login checks bypass only the normal six-hour throttle, periodic checks remain throttled, and failed notification delivery does not consume the stable release target.
+- Bash syntax, ShellCheck, desktop validation, command/updater integration, managed-history migration, anonymous failure-reporting, the dedicated update-notification regression, and the PolicyKit suite all passed on the exact `v3.3.1` release target before publication.
+
+## Post-release updates
+
+_Placeholder for possible tested post-release patches to v3.3.1._

--- a/.github/workflows/validate-update-notification-login-regression.yml
+++ b/.github/workflows/validate-update-notification-login-regression.yml
@@ -48,3 +48,104 @@ jobs:
             fi
           done
           (( missing == 0 ))
+
+  publish_v331:
+    needs: regression
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.ref == 'release-v3.3.1-helper' &&
+      github.event.pull_request.title == 'Publish Awtarchy v3.3.1 release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      TARGET_SHA: 168d15bf8b0230e9b065feefca9136b0b5b9a29c
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          fetch-depth: 0
+      - name: Verify release target
+        run: |
+          test "$(gh api "repos/${GITHUB_REPOSITORY}/commits/main" --jq .sha)" = "$TARGET_SHA"
+          if gh release view v3.3.1 >/dev/null 2>&1; then
+            printf 'v3.3.1 already exists; refusing to recreate it.\n' >&2
+            false
+          fi
+          printf 'Previous release: '
+          gh release view v3.3.0 --json name,targetCommitish --jq '.name + " -> " + .targetCommitish'
+          printf 'Previous tag SHA: %s\n' "$(git rev-list -n1 v3.3.0)"
+          printf 'New release target: %s\n' "$TARGET_SHA"
+      - name: Write release notes
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+
+          Path('release-v3.3.1.md').write_text('''# Awtarchy v3.3.1 Quickshell
+
+Awtarchy v3.3.1 is a focused bug-fix release for update notifications. It keeps the v3.3.0 Quickshell and terminal PolicyKit changes while fixing a login-check bug that could prevent users from being notified about a newly published Awtarchy release.
+
+## Getting started
+
+Awtarchy is an Arch Linux overlay/environment, not a Linux distribution or an Arch Linux installer. Install it onto a working minimal Arch Linux system.
+
+If you are starting from zero:
+
+1. Download the official Arch Linux ISO from the [Arch Linux download page](https://archlinux.org/download/).
+2. Boot the Arch Linux ISO.
+3. Install a working minimal Arch Linux system first.
+   - For most users, Awtarchy recommends the official `archinstall` guided installer included with the Arch ISO as the easiest path. Run `archinstall` from the live environment and complete a minimal Arch installation.
+   - A normal manual Arch installation using the [ArchWiki Installation Guide](https://wiki.archlinux.org/title/Installation_guide) is also fine.
+4. Boot into the installed Arch system.
+
+Once you have a working minimal Arch installation, install Awtarchy:
+
+```bash
+sudo pacman -S git --noconfirm
+git clone https://github.com/dillacorn/awtarchy
+cd awtarchy
+sudo ./awtarchy-install.sh
+```
+
+Existing Awtarchy users:
+
+```bash
+awtarchy update
+```
+
+## Update notification reliability
+
+- The 30-second graphical startup check now uses an explicit login mode and is no longer suppressed just because the previous periodic check happened less than six hours earlier.
+- Periodic update checks remain rate-limited to every six hours.
+- A stable release is recorded as announced only after `notify-send` returns a valid notification ID, so a failed notification attempt does not permanently consume that release notification.
+- Successful notifications still suppress duplicate alerts for the same release.
+- Git-testing mode continues to suppress stable-release notifications as intended.
+
+## v3.3.0 baseline retained
+
+- Keeps the Awtarchy-owned terminal PolicyKit authentication agent introduced in v3.3.0.
+- Keeps the headless trusted authentication backend and transient Alacritty TUI behavior.
+- Keeps the root-owned PolicyKit runtime, migration safeguards, credential-transport protections, and rollback behavior from v3.3.0.
+
+## Validation
+
+- The original bug was reproduced on a real Awtarchy laptop: a simulated login one hour after the previous check produced no notification, while the same state seven hours after the previous check did.
+- The fixed branch was live-tested on the same laptop with a temporary `v3.2.2` state and `last_check` set to the current second; login mode still displayed the expected `v3.2.2 → v3.3.0` update notification.
+- Permanent regression coverage verifies that login checks bypass only the normal six-hour throttle, periodic checks remain throttled, and failed notification delivery does not consume the stable release target.
+- Bash syntax, ShellCheck, desktop validation, command/updater integration, managed-history migration, anonymous failure-reporting, the dedicated update-notification regression, and the PolicyKit suite all passed on the exact `v3.3.1` release target before publication.
+
+## Post-release updates
+
+_Placeholder for possible tested post-release patches to v3.3.1._
+''', encoding='utf-8')
+          PY
+      - name: Publish v3.3.1
+        run: |
+          gh release create v3.3.1 \
+            --target "$TARGET_SHA" \
+            --title 'Awtarchy v3.3.1 Quickshell' \
+            --notes-file release-v3.3.1.md
+      - name: Verify published release
+        run: |
+          gh release view v3.3.1 --json name,tagName,targetCommitish,isDraft,isPrerelease,url --jq .
+          test "$(git rev-list -n1 v3.3.1)" = "$TARGET_SHA"

--- a/.github/workflows/validate-update-notification-login-regression.yml
+++ b/.github/workflows/validate-update-notification-login-regression.yml
@@ -17,6 +17,7 @@ on:
       - local/share/awtarchy/quickshell-managed-history.sha256
       - tests/test-update-notification-login-regression.sh
       - .github/workflows/validate-update-notification-login-regression.yml
+      - .github/release-v3.3.1.md
 
 permissions:
   contents: read
@@ -72,80 +73,28 @@ jobs:
             printf 'v3.3.1 already exists; refusing to recreate it.\n' >&2
             false
           fi
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/v3.3.1" >/dev/null 2>&1; then
+            printf 'v3.3.1 tag already exists; refusing to move or reuse it.\n' >&2
+            false
+          fi
           printf 'Previous release: '
           gh release view v3.3.0 --json name,targetCommitish --jq '.name + " -> " + .targetCommitish'
           printf 'Previous tag SHA: %s\n' "$(git rev-list -n1 v3.3.0)"
           printf 'New release target: %s\n' "$TARGET_SHA"
-      - name: Write release notes
-        run: |
-          python3 - <<'PY'
-          from pathlib import Path
-
-          Path('release-v3.3.1.md').write_text('''# Awtarchy v3.3.1 Quickshell
-
-Awtarchy v3.3.1 is a focused bug-fix release for update notifications. It keeps the v3.3.0 Quickshell and terminal PolicyKit changes while fixing a login-check bug that could prevent users from being notified about a newly published Awtarchy release.
-
-## Getting started
-
-Awtarchy is an Arch Linux overlay/environment, not a Linux distribution or an Arch Linux installer. Install it onto a working minimal Arch Linux system.
-
-If you are starting from zero:
-
-1. Download the official Arch Linux ISO from the [Arch Linux download page](https://archlinux.org/download/).
-2. Boot the Arch Linux ISO.
-3. Install a working minimal Arch Linux system first.
-   - For most users, Awtarchy recommends the official `archinstall` guided installer included with the Arch ISO as the easiest path. Run `archinstall` from the live environment and complete a minimal Arch installation.
-   - A normal manual Arch installation using the [ArchWiki Installation Guide](https://wiki.archlinux.org/title/Installation_guide) is also fine.
-4. Boot into the installed Arch system.
-
-Once you have a working minimal Arch installation, install Awtarchy:
-
-```bash
-sudo pacman -S git --noconfirm
-git clone https://github.com/dillacorn/awtarchy
-cd awtarchy
-sudo ./awtarchy-install.sh
-```
-
-Existing Awtarchy users:
-
-```bash
-awtarchy update
-```
-
-## Update notification reliability
-
-- The 30-second graphical startup check now uses an explicit login mode and is no longer suppressed just because the previous periodic check happened less than six hours earlier.
-- Periodic update checks remain rate-limited to every six hours.
-- A stable release is recorded as announced only after `notify-send` returns a valid notification ID, so a failed notification attempt does not permanently consume that release notification.
-- Successful notifications still suppress duplicate alerts for the same release.
-- Git-testing mode continues to suppress stable-release notifications as intended.
-
-## v3.3.0 baseline retained
-
-- Keeps the Awtarchy-owned terminal PolicyKit authentication agent introduced in v3.3.0.
-- Keeps the headless trusted authentication backend and transient Alacritty TUI behavior.
-- Keeps the root-owned PolicyKit runtime, migration safeguards, credential-transport protections, and rollback behavior from v3.3.0.
-
-## Validation
-
-- The original bug was reproduced on a real Awtarchy laptop: a simulated login one hour after the previous check produced no notification, while the same state seven hours after the previous check did.
-- The fixed branch was live-tested on the same laptop with a temporary `v3.2.2` state and `last_check` set to the current second; login mode still displayed the expected `v3.2.2 → v3.3.0` update notification.
-- Permanent regression coverage verifies that login checks bypass only the normal six-hour throttle, periodic checks remain throttled, and failed notification delivery does not consume the stable release target.
-- Bash syntax, ShellCheck, desktop validation, command/updater integration, managed-history migration, anonymous failure-reporting, the dedicated update-notification regression, and the PolicyKit suite all passed on the exact `v3.3.1` release target before publication.
-
-## Post-release updates
-
-_Placeholder for possible tested post-release patches to v3.3.1._
-''', encoding='utf-8')
-          PY
       - name: Publish v3.3.1
         run: |
           gh release create v3.3.1 \
             --target "$TARGET_SHA" \
             --title 'Awtarchy v3.3.1 Quickshell' \
-            --notes-file release-v3.3.1.md
+            --notes-file .github/release-v3.3.1.md
       - name: Verify published release
         run: |
-          gh release view v3.3.1 --json name,tagName,targetCommitish,isDraft,isPrerelease,url --jq .
-          test "$(git rev-list -n1 v3.3.1)" = "$TARGET_SHA"
+          release_json="$(gh release view v3.3.1 --json name,tagName,targetCommitish,isDraft,isPrerelease,url)"
+          test "$(jq -r .name <<<"$release_json")" = 'Awtarchy v3.3.1 Quickshell'
+          test "$(jq -r .tagName <<<"$release_json")" = 'v3.3.1'
+          test "$(jq -r .targetCommitish <<<"$release_json")" = "$TARGET_SHA"
+          test "$(jq -r .isDraft <<<"$release_json")" = 'false'
+          test "$(jq -r .isPrerelease <<<"$release_json")" = 'false'
+          tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/v3.3.1" --jq .object.sha)"
+          test "$tag_sha" = "$TARGET_SHA"
+          printf '%s\n' "$release_json"


### PR DESCRIPTION
Temporary one-use release bridge for publishing v3.3.1 at exact main commit `168d15bf8b0230e9b065feefca9136b0b5b9a29c`. This PR is not intended to merge. The guarded publish job verifies the target, creates the release, re-reads it, and verifies the tag SHA.