### PR TITLE
Publish Awtarchy v3.3.2 release

### DIFF
--- a/.github/release-v3.3.2.md
+++ b/.github/release-v3.3.2.md
@@ -1,0 +1,65 @@
+# Awtarchy v3.3.2 Quickshell
+
+Awtarchy v3.3.2 is a focused bug-fix release for Bluetooth state synchronization in Quickshell. It keeps the v3.3.1 update-notification fixes and v3.3.0 terminal PolicyKit changes while fixing a startup condition where Bluetooth could be correctly powered off underneath but still appear enabled in the Awtarchy bar and Bluetooth menu.
+
+## Getting started
+
+Awtarchy is an Arch Linux overlay/environment, not a Linux distribution or an Arch Linux installer. Install it onto a working minimal Arch Linux system.
+
+If you are starting from zero:
+
+1. Download the official Arch Linux ISO from the [Arch Linux download page](https://archlinux.org/download/).
+2. Boot the Arch Linux ISO.
+3. Install a working minimal Arch Linux system first.
+   - For most users, Awtarchy recommends the official `archinstall` guided installer included with the Arch ISO as the easiest path. Run `archinstall` from the live environment and complete a minimal Arch installation.
+   - A normal manual Arch installation using the [ArchWiki Installation Guide](https://wiki.archlinux.org/title/Installation_guide) is also fine.
+4. Boot into the installed Arch system.
+
+Once you have a working minimal Arch installation, install Awtarchy:
+
+```bash
+sudo pacman -S git --noconfirm
+git clone https://github.com/dillacorn/awtarchy
+cd awtarchy
+sudo ./awtarchy-install.sh
+```
+
+Existing Awtarchy users:
+
+```bash
+awtarchy update
+```
+
+## Bluetooth state synchronization
+
+- The Bluetooth state helper can now read the actual BlueZ controller power state directly from `bluetoothctl show`.
+- Quickshell reconciles its displayed Bluetooth state after startup restore, enable, and disable operations instead of relying only on the cached `BluetoothAdapter.enabled` value.
+- The bar and Bluetooth menu now reflect the actual powered state when the saved Awtarchy preference is restored during login.
+- Bluetooth enable/disable actions immediately update the reconciled state and then verify it against BlueZ.
+- Awtarchy continues to leave Bluetooth rfkill unblocked while powering the controller off, so the adapter remains visible and can be turned back on normally.
+
+## v3.3.1 reliability fixes retained
+
+- Keeps the explicit 30-second login update check introduced in v3.3.1.
+- Keeps periodic update checks rate-limited to every six hours.
+- Keeps failed notification delivery from consuming a stable release notification target.
+- Git-testing mode continues to suppress stable-release notifications as intended.
+
+## v3.3.0 baseline retained
+
+- Keeps the Awtarchy-owned terminal PolicyKit authentication agent introduced in v3.3.0.
+- Keeps the headless trusted authentication backend and transient Alacritty TUI behavior.
+- Keeps the root-owned PolicyKit runtime, migration safeguards, credential-transport protections, and rollback behavior from v3.3.0.
+
+## Validation
+
+- The Bluetooth bug was reproduced on a real Awtarchy laptop: the saved preference was `disabled` and BlueZ reported `Powered: no`, while the Quickshell bar/menu incorrectly displayed Bluetooth as enabled and could not meaningfully turn it off again.
+- The fix was runtime-tested on the same laptop. Saved and actual state matched as `disabled`, then `enabled`, then `disabled` while toggling through the Quickshell Bluetooth UI.
+- After restarting Quickshell with Bluetooth disabled, the UI remained correctly displayed as off.
+- After a full reboot and login with Bluetooth disabled, the bar/menu still displayed Bluetooth as off, confirming the original startup failure was fixed in real use.
+- Permanent Bluetooth regression coverage verifies actual BlueZ power readback, Quickshell synchronization wiring, Bash syntax, ShellCheck, and managed-history registration.
+- The full Awtarchy command/updater integration suite, focused Bluetooth validation, update-notification regression, anonymous failure-reporting validation, and PolicyKit contracts all passed on the exact `v3.3.2` release target before publication.
+
+## Post-release updates
+
+_Placeholder for possible tested post-release patches to v3.3.2._

--- a/.github/workflows/validate-bluetooth-state.yml
+++ b/.github/workflows/validate-bluetooth-state.yml
@@ -10,6 +10,7 @@ on:
       - local/share/awtarchy/quickshell-managed-history.sha256
       - tests/test-bluetooth-state-persistence.sh
       - .github/workflows/validate-bluetooth-state.yml
+      - .github/release-v3.3.2.md
   pull_request:
     paths:
       - config/hypr/scripts/quickshell_bluetooth_state.sh
@@ -17,6 +18,7 @@ on:
       - local/share/awtarchy/quickshell-managed-history.sha256
       - tests/test-bluetooth-state-persistence.sh
       - .github/workflows/validate-bluetooth-state.yml
+      - .github/release-v3.3.2.md
 
 permissions:
   contents: read
@@ -50,3 +52,52 @@ jobs:
             fi
           done
           (( missing == 0 ))
+
+  publish_v332:
+    needs: bluetooth-state
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.ref == 'release-v3.3.2-helper' &&
+      github.event.pull_request.title == 'Publish Awtarchy v3.3.2 release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      TARGET_SHA: d283cd7ac730a5c9f3e1d80c780341cb3599114b
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          fetch-depth: 0
+      - name: Verify release target
+        run: |
+          test "$(gh api "repos/${GITHUB_REPOSITORY}/commits/main" --jq .sha)" = "$TARGET_SHA"
+          if gh release view v3.3.2 >/dev/null 2>&1; then
+            printf 'v3.3.2 already exists; refusing to recreate it.\n' >&2
+            false
+          fi
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/v3.3.2" >/dev/null 2>&1; then
+            printf 'v3.3.2 tag already exists; refusing to move or reuse it.\n' >&2
+            false
+          fi
+          printf 'Previous release: '
+          gh release view v3.3.1 --json name,targetCommitish --jq '.name + " -> " + .targetCommitish'
+          printf 'Previous tag SHA: %s\n' "$(git rev-list -n1 v3.3.1)"
+          printf 'New release target: %s\n' "$TARGET_SHA"
+      - name: Publish v3.3.2
+        run: |
+          gh release create v3.3.2 \
+            --target "$TARGET_SHA" \
+            --title 'Awtarchy v3.3.2 Quickshell' \
+            --notes-file .github/release-v3.3.2.md
+      - name: Verify published release
+        run: |
+          release_json="$(gh release view v3.3.2 --json name,tagName,targetCommitish,isDraft,isPrerelease,url)"
+          test "$(jq -r .name <<<"$release_json")" = 'Awtarchy v3.3.2 Quickshell'
+          test "$(jq -r .tagName <<<"$release_json")" = 'v3.3.2'
+          test "$(jq -r .targetCommitish <<<"$release_json")" = "$TARGET_SHA"
+          test "$(jq -r .isDraft <<<"$release_json")" = 'false'
+          test "$(jq -r .isPrerelease <<<"$release_json")" = 'false'
+          tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/v3.3.2" --jq .object.sha)"
+          test "$tag_sha" = "$TARGET_SHA"
+          printf '%s\n' "$release_json"


### PR DESCRIPTION
Temporary guarded release helper for v3.3.2. Targets exact validated main commit d283cd7ac730a5c9f3e1d80c780341cb3599114b. The workflow refuses to publish if main moves or if the v3.3.2 release/tag already exists. Close without merging after the published release and tag are independently verified.