### PR TITLE
Test headless Hyprland and Quickshell runtime

### DIFF
--- a/.github/scripts/headless-quickshell-runtime-smoke.sh
+++ b/.github/scripts/headless-quickshell-runtime-smoke.sh
@@ -8,9 +8,19 @@ OUT="${ARTIFACT_DIR}/${SAFE_TARGET}"
 mkdir -p "$OUT"
 
 pacman -Syu --noconfirm --needed \
-    hyprland quickshell jq python dbus mesa wl-clipboard cliphist grim foot \
+    hyprland quickshell jq python dbus mesa mesa-utils wl-clipboard cliphist grim foot weston \
     xdg-utils util-linux procps-ng libnotify qt6-wayland ttf-dejavu \
     >"$OUT/pacman.log" 2>&1
+
+{
+    printf '%s\n' '=== /dev/dri ==='
+    ls -la /dev/dri 2>&1 || true
+    printf '%s\n' '=== DRM devices ==='
+    for node in /dev/dri/card* /dev/dri/renderD*; do
+        [[ -e "$node" ]] || continue
+        printf '%s\n' "$node"
+    done
+} >"$OUT/drm-devices.txt"
 
 id tester >/dev/null 2>&1 || useradd -m -u 1000 tester
 install -d -m 0700 -o tester -g tester /run/user/1000
@@ -37,43 +47,120 @@ export HYPRLAND_NO_SD_VARS=1
 export HYPRLAND_NO_RT=1
 export AQ_NO_KMS_REQUIREMENT=1
 export AQ_NO_MODIFIERS=1
-export LIBGL_ALWAYS_SOFTWARE=1
 export WLR_RENDERER_ALLOW_SOFTWARE=1
 export QT_QPA_PLATFORM=wayland
 
 HYPR_LOG="$OUT/hyprland.log"
 QS_LOG="$OUT/quickshell-manager.log"
+WESTON_LOG="$OUT/weston.log"
 : >"$HYPR_LOG"
 : >"$QS_LOG"
+: >"$WESTON_LOG"
 
-Hyprland --config "$HOME/.config/hypr/hyprland.lua" >"$HYPR_LOG" 2>&1 &
-HYPR_PID=$!
+WESTON_PID=""
+HYPR_PID=""
 cleanup() {
     qs -c awtarchy ipc call control quit >/dev/null 2>&1 || true
-    kill "$HYPR_PID" >/dev/null 2>&1 || true
-    wait "$HYPR_PID" >/dev/null 2>&1 || true
+    if [[ -n "$HYPR_PID" ]]; then
+        kill "$HYPR_PID" >/dev/null 2>&1 || true
+        wait "$HYPR_PID" >/dev/null 2>&1 || true
+    fi
+    if [[ -n "$WESTON_PID" ]]; then
+        kill "$WESTON_PID" >/dev/null 2>&1 || true
+        wait "$WESTON_PID" >/dev/null 2>&1 || true
+    fi
 }
 trap cleanup EXIT
 
+# Prefer a real virtual DRM allocator. Mesa selects kms_swrast for VGEM when
+# software rendering is requested, while Hyprland is allowed to use a GPU that
+# has no physical KMS outputs. The resulting compositor creates HEADLESS-0.
+DRM_CARD="$(find /dev/dri -maxdepth 1 -type c -name 'card*' -print -quit 2>/dev/null || true)"
+if [[ -n "$DRM_CARD" ]]; then
+    export AQ_DRM_DEVICES="$DRM_CARD"
+    export LIBGL_ALWAYS_SOFTWARE=1
+    printf 'direct-drm:%s\n' "$DRM_CARD" >"$OUT/backend-mode.txt"
+else
+    # Fallback: give Aquamarine a real outer Wayland compositor. Weston itself
+    # is fully software rendered and needs no host GPU.
+    WESTON_SOCKET=wayland-awtarchy-ci
+    LIBGL_ALWAYS_SOFTWARE=1 weston \
+        -B headless \
+        --renderer=pixman \
+        --socket="$WESTON_SOCKET" \
+        --width=1920 \
+        --height=1080 \
+        --log="$WESTON_LOG" &
+    WESTON_PID=$!
+
+    for _ in $(seq 1 100); do
+        [[ -S "$XDG_RUNTIME_DIR/$WESTON_SOCKET" ]] && break
+        if ! kill -0 "$WESTON_PID" 2>/dev/null; then
+            printf '%s\n' 'Weston fallback exited before creating its Wayland socket.' >&2
+            cat "$WESTON_LOG" >&2
+            exit 1
+        fi
+        sleep 0.1
+    done
+    [[ -S "$XDG_RUNTIME_DIR/$WESTON_SOCKET" ]] || {
+        printf '%s\n' 'Timed out waiting for Weston fallback.' >&2
+        cat "$WESTON_LOG" >&2
+        exit 1
+    }
+
+    export WAYLAND_DISPLAY="$WESTON_SOCKET"
+    unset LIBGL_ALWAYS_SOFTWARE
+    printf 'nested-wayland:%s\n' "$WESTON_SOCKET" >"$OUT/backend-mode.txt"
+fi
+
+{
+    printf '%s\n' '=== environment before Hyprland ==='
+    printf 'WAYLAND_DISPLAY=%s\n' "${WAYLAND_DISPLAY:-}"
+    printf 'AQ_DRM_DEVICES=%s\n' "${AQ_DRM_DEVICES:-}"
+    printf 'LIBGL_ALWAYS_SOFTWARE=%s\n' "${LIBGL_ALWAYS_SOFTWARE:-}"
+    printf '%s\n' '=== eglinfo ==='
+    eglinfo -B 2>&1 || true
+} >"$OUT/render-environment.txt"
+
+Hyprland --config "$HOME/.config/hypr/hyprland.lua" >"$HYPR_LOG" 2>&1 &
+HYPR_PID=$!
+
 LOCK=""
-for _ in $(seq 1 120); do
+for _ in $(seq 1 160); do
     LOCK="$(find "$XDG_RUNTIME_DIR/hypr" -mindepth 2 -maxdepth 2 -name hyprland.lock -print -quit 2>/dev/null || true)"
     [[ -n "$LOCK" ]] && break
     if ! kill -0 "$HYPR_PID" 2>/dev/null; then
         printf '%s\n' 'Hyprland exited before creating a runtime lock.' >&2
         cat "$HYPR_LOG" >&2
+        [[ -s "$WESTON_LOG" ]] && { printf '%s\n' '=== Weston ===' >&2; cat "$WESTON_LOG" >&2; }
         exit 1
     fi
     sleep 0.1
 done
-[[ -n "$LOCK" ]] || { printf '%s\n' 'Timed out waiting for Hyprland runtime lock.' >&2; cat "$HYPR_LOG" >&2; exit 1; }
+[[ -n "$LOCK" ]] || {
+    printf '%s\n' 'Timed out waiting for Hyprland runtime lock.' >&2
+    cat "$HYPR_LOG" >&2
+    exit 1
+}
 
 export HYPRLAND_INSTANCE_SIGNATURE="$(basename "$(dirname "$LOCK")")"
 export WAYLAND_DISPLAY="$(sed -n '2p' "$LOCK")"
 printf '%s\n' "$HYPRLAND_INSTANCE_SIGNATURE" >"$OUT/hyprland-instance.txt"
 printf '%s\n' "$WAYLAND_DISPLAY" >"$OUT/wayland-display.txt"
 
-hyprctl -j monitors >"$OUT/monitors-initial.json"
+for _ in $(seq 1 100); do
+    if hyprctl -j monitors >"$OUT/monitors-initial.json" 2>/dev/null && \
+        jq -e 'length > 0' "$OUT/monitors-initial.json" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 0.1
+done
+jq -e 'length > 0' "$OUT/monitors-initial.json" >/dev/null || {
+    printf '%s\n' 'Hyprland started but never exposed an output.' >&2
+    cat "$HYPR_LOG" >&2
+    exit 1
+}
+
 hyprctl configerrors >"$OUT/configerrors-initial.txt"
 if [[ -s "$OUT/configerrors-initial.txt" ]]; then
     printf '%s\n' 'Hyprland reported config errors at startup:' >&2
@@ -88,7 +175,7 @@ fi
 }
 
 QS_READY=0
-for _ in $(seq 1 120); do
+for _ in $(seq 1 160); do
     if qs -c awtarchy ipc call control ping >/dev/null 2>&1; then
         QS_READY=1
         break
@@ -109,20 +196,17 @@ hyprctl -j layers >"$OUT/layers-before.json"
 sleep 0.8
 qs -c awtarchy ipc call control ping >/dev/null
 hyprctl -j layers >"$OUT/layers-quicksettings.json"
-grim "$OUT/quicksettings.png"
+grim "$OUT/quicksettings.png" || true
 "$HOME/.config/hypr/scripts/quickshell_quick_settings_toggle.sh"
 sleep 0.2
 
 case "$TARGET_REF" in
     feature/progressive-clipboard-loading)
-        # Ensure the real clipboard watcher exists even if unrelated CI-only
-        # session services prevented the normal Hyprland autostart from doing it.
         if ! pgrep -f 'wl-paste --type text --watch cliphist store' >/dev/null; then
             wl-paste --type text --watch cliphist store >/dev/null 2>&1 &
             sleep 0.2
         fi
 
-        # Drive real Wayland clipboard traffic through cliphist.
         for n in $(seq 1 80); do
             printf 'Awtarchy runtime clipboard item %03d' "$n" | wl-copy
             sleep 0.015
@@ -136,8 +220,8 @@ case "$TARGET_REF" in
         "$HOME/.config/hypr/scripts/quickshell_clipboard_toggle.sh"
         sleep 1
         qs -c awtarchy ipc call control ping >/dev/null
-        grim "$OUT/clipboard.png"
-        # Rapid close/reopen probes generation/process cleanup under a live compositor.
+        hyprctl -j layers >"$OUT/layers-clipboard.json"
+        grim "$OUT/clipboard.png" || true
         for _ in $(seq 1 4); do
             "$HOME/.config/hypr/scripts/quickshell_clipboard_toggle.sh"
             sleep 0.08
@@ -174,7 +258,8 @@ case "$TARGET_REF" in
         "$HOME/.config/hypr/scripts/quickshell_quick_settings_toggle.sh"
         sleep 0.8
         qs -c awtarchy ipc call control ping >/dev/null
-        grim "$OUT/quicksettings-custom-layout.png"
+        hyprctl -j layers >"$OUT/layers-custom-layout.json"
+        grim "$OUT/quicksettings-custom-layout.png" || true
         "$HOME/.config/hypr/scripts/quickshell_quick_settings_toggle.sh"
         ;;
 
@@ -213,7 +298,6 @@ case "$TARGET_REF" in
         ;;
 esac
 
-# Fail on runtime-level QML/config loader errors, while retaining complete logs.
 if [[ -f "$HOME/.cache/awtarchy/quickshell.log" ]]; then
     cp "$HOME/.cache/awtarchy/quickshell.log" "$OUT/quickshell.log"
     if grep -Eiq 'QQmlApplicationEngine failed|QQmlComponent: Component is not ready|Type .* unavailable|module .* is not installed|SyntaxError:|ReferenceError:' "$OUT/quickshell.log"; then

--- a/.github/scripts/headless-quickshell-runtime-smoke.sh
+++ b/.github/scripts/headless-quickshell-runtime-smoke.sh
@@ -8,7 +8,7 @@ OUT="${ARTIFACT_DIR}/${SAFE_TARGET}"
 mkdir -p "$OUT"
 
 pacman -Syu --noconfirm --needed \
-    hyprland quickshell jq python dbus mesa mesa-utils wl-clipboard cliphist grim foot weston \
+    hyprland quickshell jq python dbus mesa mesa-utils wl-clipboard cliphist grim foot weston wayland-utils \
     xdg-utils util-linux procps-ng libnotify qt6-wayland ttf-dejavu \
     >"$OUT/pacman.log" 2>&1
 
@@ -72,45 +72,64 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Prefer a real virtual DRM allocator. Mesa selects kms_swrast for VGEM when
-# software rendering is requested, while Hyprland is allowed to use a GPU that
-# has no physical KMS outputs. The resulting compositor creates HEADLESS-0.
-DRM_CARD="$(find /dev/dri -maxdepth 1 -type c -name 'card*' -print -quit 2>/dev/null || true)"
+DRM_CARD=""
+if [[ ${FORCE_NESTED_WESTON:-0} != 1 ]]; then
+    DRM_CARD="$(find /dev/dri -maxdepth 1 -type c -name 'card*' -print -quit 2>/dev/null || true)"
+fi
+
 if [[ -n "$DRM_CARD" ]]; then
     export AQ_DRM_DEVICES="$DRM_CARD"
     export LIBGL_ALWAYS_SOFTWARE=1
     printf 'direct-drm:%s\n' "$DRM_CARD" >"$OUT/backend-mode.txt"
 else
-    # Fallback: give Aquamarine a real outer Wayland compositor. Weston itself
-    # is fully software rendered and needs no host GPU.
+    # Aquamarine's nested Wayland backend requires a real Wayland compositor
+    # with dmabuf support. Weston headless + GL is software rendered by Mesa's
+    # llvmpipe here, but still uses the GL renderer rather than the pixman path.
     WESTON_SOCKET=wayland-awtarchy-ci
-    LIBGL_ALWAYS_SOFTWARE=1 weston \
+    export LIBGL_ALWAYS_SOFTWARE=1
+    weston \
         -B headless \
-        --renderer=pixman \
+        --renderer=gl \
         --socket="$WESTON_SOCKET" \
         --width=1920 \
         --height=1080 \
         --log="$WESTON_LOG" &
     WESTON_PID=$!
 
-    for _ in $(seq 1 100); do
+    for _ in $(seq 1 120); do
         [[ -S "$XDG_RUNTIME_DIR/$WESTON_SOCKET" ]] && break
         if ! kill -0 "$WESTON_PID" 2>/dev/null; then
-            printf '%s\n' 'Weston fallback exited before creating its Wayland socket.' >&2
+            printf '%s\n' 'Weston GL fallback exited before creating its Wayland socket.' >&2
             cat "$WESTON_LOG" >&2
             exit 1
         fi
         sleep 0.1
     done
     [[ -S "$XDG_RUNTIME_DIR/$WESTON_SOCKET" ]] || {
-        printf '%s\n' 'Timed out waiting for Weston fallback.' >&2
+        printf '%s\n' 'Timed out waiting for Weston GL fallback.' >&2
         cat "$WESTON_LOG" >&2
         exit 1
     }
 
+    WAYLAND_DISPLAY="$WESTON_SOCKET" wayland-info >"$OUT/outer-wayland-info.txt" 2>&1 || {
+        printf '%s\n' 'wayland-info could not inspect the outer Weston compositor.' >&2
+        cat "$OUT/outer-wayland-info.txt" >&2
+        exit 1
+    }
+
+    for required in wl_shm wl_seat xdg_wm_base zwp_linux_dmabuf_v1; do
+        if ! grep -Fq -- "$required" "$OUT/outer-wayland-info.txt"; then
+            printf 'Outer Weston is missing required Wayland global: %s\n' "$required" >&2
+            cat "$OUT/outer-wayland-info.txt" >&2
+            exit 1
+        fi
+    done
+
     export WAYLAND_DISPLAY="$WESTON_SOCKET"
-    unset LIBGL_ALWAYS_SOFTWARE
-    printf 'nested-wayland:%s\n' "$WESTON_SOCKET" >"$OUT/backend-mode.txt"
+    unset AQ_DRM_DEVICES
+    # Keep LIBGL_ALWAYS_SOFTWARE=1 so both Weston and nested Hyprland use Mesa
+    # software rendering instead of trying the Azure VM's unrelated DRM node.
+    printf 'nested-wayland-gl:%s\n' "$WESTON_SOCKET" >"$OUT/backend-mode.txt"
 fi
 
 {
@@ -191,7 +210,6 @@ fi
 qs -c awtarchy list --json >"$OUT/quickshell-instances.json"
 hyprctl -j layers >"$OUT/layers-before.json"
 
-# Open the real Quick Settings surface and verify the shell survives it.
 "$HOME/.config/hypr/scripts/quickshell_quick_settings_toggle.sh"
 sleep 0.8
 qs -c awtarchy ipc call control ping >/dev/null
@@ -315,5 +333,8 @@ SESSION
 chmod 0755 /tmp/runtime-session.sh
 chown tester:tester /tmp/runtime-session.sh "$OUT"
 
-runuser -u tester -- env TARGET_REF="$TARGET_REF" OUT="$OUT" \
+runuser -u tester -- env \
+    TARGET_REF="$TARGET_REF" \
+    OUT="$OUT" \
+    FORCE_NESTED_WESTON="${FORCE_NESTED_WESTON:-0}" \
     dbus-run-session -- /tmp/runtime-session.sh

--- a/.github/scripts/headless-quickshell-runtime-smoke.sh
+++ b/.github/scripts/headless-quickshell-runtime-smoke.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+TARGET_REF="${TARGET_REF:?TARGET_REF is required}"
+ARTIFACT_DIR="${ARTIFACT_DIR:-/artifacts}"
+SAFE_TARGET="${TARGET_REF//\//_}"
+OUT="${ARTIFACT_DIR}/${SAFE_TARGET}"
+mkdir -p "$OUT"
+
+pacman -Syu --noconfirm --needed \
+    hyprland quickshell jq python dbus mesa wl-clipboard cliphist grim foot \
+    xdg-utils util-linux procps-ng libnotify qt6-wayland ttf-dejavu \
+    >"$OUT/pacman.log" 2>&1
+
+id tester >/dev/null 2>&1 || useradd -m -u 1000 tester
+install -d -m 0700 -o tester -g tester /run/user/1000
+install -d -o tester -g tester /home/tester/.config /home/tester/.cache
+rm -rf /home/tester/.config/hypr /home/tester/.config/quickshell
+cp -a /repo/config/hypr /home/tester/.config/hypr
+cp -a /repo/config/quickshell /home/tester/.config/quickshell
+chown -R tester:tester /home/tester/.config /home/tester/.cache
+find /home/tester/.config/hypr/scripts -type f -name '*.sh' -exec chmod u+x {} +
+
+cat > /tmp/runtime-session.sh <<'SESSION'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+TARGET_REF="${TARGET_REF:?}"
+OUT="${OUT:?}"
+export HOME=/home/tester
+export XDG_CONFIG_HOME="$HOME/.config"
+export XDG_CACHE_HOME="$HOME/.cache"
+export XDG_RUNTIME_DIR=/run/user/1000
+export XDG_SESSION_TYPE=wayland
+export XDG_CURRENT_DESKTOP=Hyprland
+export HYPRLAND_NO_SD_VARS=1
+export HYPRLAND_NO_RT=1
+export AQ_NO_KMS_REQUIREMENT=1
+export AQ_NO_MODIFIERS=1
+export LIBGL_ALWAYS_SOFTWARE=1
+export WLR_RENDERER_ALLOW_SOFTWARE=1
+export QT_QPA_PLATFORM=wayland
+
+HYPR_LOG="$OUT/hyprland.log"
+QS_LOG="$OUT/quickshell-manager.log"
+: >"$HYPR_LOG"
+: >"$QS_LOG"
+
+Hyprland --config "$HOME/.config/hypr/hyprland.lua" >"$HYPR_LOG" 2>&1 &
+HYPR_PID=$!
+cleanup() {
+    qs -c awtarchy ipc call control quit >/dev/null 2>&1 || true
+    kill "$HYPR_PID" >/dev/null 2>&1 || true
+    wait "$HYPR_PID" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+LOCK=""
+for _ in $(seq 1 120); do
+    LOCK="$(find "$XDG_RUNTIME_DIR/hypr" -mindepth 2 -maxdepth 2 -name hyprland.lock -print -quit 2>/dev/null || true)"
+    [[ -n "$LOCK" ]] && break
+    if ! kill -0 "$HYPR_PID" 2>/dev/null; then
+        printf '%s\n' 'Hyprland exited before creating a runtime lock.' >&2
+        cat "$HYPR_LOG" >&2
+        exit 1
+    fi
+    sleep 0.1
+done
+[[ -n "$LOCK" ]] || { printf '%s\n' 'Timed out waiting for Hyprland runtime lock.' >&2; cat "$HYPR_LOG" >&2; exit 1; }
+
+export HYPRLAND_INSTANCE_SIGNATURE="$(basename "$(dirname "$LOCK")")"
+export WAYLAND_DISPLAY="$(sed -n '2p' "$LOCK")"
+printf '%s\n' "$HYPRLAND_INSTANCE_SIGNATURE" >"$OUT/hyprland-instance.txt"
+printf '%s\n' "$WAYLAND_DISPLAY" >"$OUT/wayland-display.txt"
+
+hyprctl -j monitors >"$OUT/monitors-initial.json"
+hyprctl configerrors >"$OUT/configerrors-initial.txt"
+if [[ -s "$OUT/configerrors-initial.txt" ]]; then
+    printf '%s\n' 'Hyprland reported config errors at startup:' >&2
+    cat "$OUT/configerrors-initial.txt" >&2
+    exit 1
+fi
+
+"$HOME/.config/hypr/scripts/quickshell.sh" start >"$QS_LOG" 2>&1 || {
+    cat "$QS_LOG" >&2
+    [[ -f "$HOME/.cache/awtarchy/quickshell.log" ]] && cat "$HOME/.cache/awtarchy/quickshell.log" >&2
+    exit 1
+}
+
+QS_READY=0
+for _ in $(seq 1 120); do
+    if qs -c awtarchy ipc call control ping >/dev/null 2>&1; then
+        QS_READY=1
+        break
+    fi
+    sleep 0.1
+done
+if (( QS_READY == 0 )); then
+    printf '%s\n' 'Quickshell did not become IPC-ready.' >&2
+    [[ -f "$HOME/.cache/awtarchy/quickshell.log" ]] && cat "$HOME/.cache/awtarchy/quickshell.log" >&2
+    exit 1
+fi
+
+qs -c awtarchy list --json >"$OUT/quickshell-instances.json"
+hyprctl -j layers >"$OUT/layers-before.json"
+
+# Open the real Quick Settings surface and verify the shell survives it.
+"$HOME/.config/hypr/scripts/quickshell_quick_settings_toggle.sh"
+sleep 0.8
+qs -c awtarchy ipc call control ping >/dev/null
+hyprctl -j layers >"$OUT/layers-quicksettings.json"
+grim "$OUT/quicksettings.png"
+"$HOME/.config/hypr/scripts/quickshell_quick_settings_toggle.sh"
+sleep 0.2
+
+case "$TARGET_REF" in
+    feature/progressive-clipboard-loading)
+        # Ensure the real clipboard watcher exists even if unrelated CI-only
+        # session services prevented the normal Hyprland autostart from doing it.
+        if ! pgrep -f 'wl-paste --type text --watch cliphist store' >/dev/null; then
+            wl-paste --type text --watch cliphist store >/dev/null 2>&1 &
+            sleep 0.2
+        fi
+
+        # Drive real Wayland clipboard traffic through cliphist.
+        for n in $(seq 1 80); do
+            printf 'Awtarchy runtime clipboard item %03d' "$n" | wl-copy
+            sleep 0.015
+        done
+        sleep 0.8
+        cliphist list >"$OUT/cliphist-list.txt"
+        [[ "$(wc -l <"$OUT/cliphist-list.txt")" -ge 60 ]] || {
+            printf '%s\n' 'Expected at least 60 clipboard records.' >&2
+            exit 1
+        }
+        "$HOME/.config/hypr/scripts/quickshell_clipboard_toggle.sh"
+        sleep 1
+        qs -c awtarchy ipc call control ping >/dev/null
+        grim "$OUT/clipboard.png"
+        # Rapid close/reopen probes generation/process cleanup under a live compositor.
+        for _ in $(seq 1 4); do
+            "$HOME/.config/hypr/scripts/quickshell_clipboard_toggle.sh"
+            sleep 0.08
+            "$HOME/.config/hypr/scripts/quickshell_clipboard_toggle.sh"
+            sleep 0.08
+        done
+        qs -c awtarchy ipc call control ping >/dev/null
+        ;;
+
+    feature/focused-display-scale)
+        MONITOR="$(hyprctl -j monitors | jq -r '.[0].name')"
+        "$HOME/.config/hypr/scripts/quickshell_display_scale.sh" status "$MONITOR" >"$OUT/display-scale-before.json"
+        "$HOME/.config/hypr/scripts/quickshell_display_scale.sh" set "$MONITOR" 1.25 >"$OUT/display-scale-set-125.json"
+        ACTUAL_SCALE="$(hyprctl -j monitors | jq -r --arg m "$MONITOR" '.[] | select(.name == $m) | .scale')"
+        awk -v s="$ACTUAL_SCALE" 'BEGIN { exit !(s > 1.24 && s < 1.26) }' || {
+            printf 'Expected live scale 1.25, got %s\n' "$ACTUAL_SCALE" >&2
+            exit 1
+        }
+        "$HOME/.config/hypr/scripts/quickshell_display_scale.sh" set "$MONITOR" 1 >"$OUT/display-scale-set-100.json"
+        hyprctl configerrors >"$OUT/configerrors-after-scale.txt"
+        [[ ! -s "$OUT/configerrors-after-scale.txt" ]]
+        ;;
+
+    feature/quick-settings-layout-customization)
+        MONITOR="$(hyprctl -j monitors | jq -r '.[0].name')"
+        ORDER='["title-bars","brightness","output-volume","power-mode","bar","display-effects","submap","wallpaper","awtarchy","smtty","scheduler","numlock"]'
+        HIDDEN='["smtty"]'
+        "$HOME/.config/hypr/scripts/quickshell_application_state.sh" \
+            save-quick-settings-layout "$MONITOR" "$ORDER" "$HIDDEN"
+        jq -e --arg m "$MONITOR" \
+            '.quick_settings_layouts[$m].order[0] == "title-bars" and (.quick_settings_layouts[$m].hidden | index("smtty") != null)' \
+            "$HOME/.cache/awtarchy/quickshell-state.json" >/dev/null
+        qs -c awtarchy ipc call control ping >/dev/null
+        "$HOME/.config/hypr/scripts/quickshell_quick_settings_toggle.sh"
+        sleep 0.8
+        qs -c awtarchy ipc call control ping >/dev/null
+        grim "$OUT/quicksettings-custom-layout.png"
+        "$HOME/.config/hypr/scripts/quickshell_quick_settings_toggle.sh"
+        ;;
+
+    feature/floating-windows-default)
+        helper="$HOME/.config/hypr/scripts/quickshell_floating_windows.sh"
+        [[ "$($helper status)" == disabled ]]
+
+        foot --app-id awtarchy-tiled-check --title awtarchy-tiled-check >/dev/null 2>&1 &
+        sleep 0.6
+        BASE_FLOAT="$(hyprctl -j clients | jq -r '.[] | select(.class == "awtarchy-tiled-check") | .floating' | head -n1)"
+        [[ "$BASE_FLOAT" == false ]] || { printf 'Stock window unexpectedly floating: %s\n' "$BASE_FLOAT" >&2; exit 1; }
+        pkill -f 'foot.*awtarchy-tiled-check' || true
+        sleep 0.2
+
+        [[ "$($helper set on)" == enabled ]]
+        foot --app-id awtarchy-floating-check --title awtarchy-floating-check >/dev/null 2>&1 &
+        sleep 0.6
+        FLOATING="$(hyprctl -j clients | jq -r '.[] | select(.class == "awtarchy-floating-check") | .floating' | head -n1)"
+        [[ "$FLOATING" == true ]] || { printf 'Enabled window did not float: %s\n' "$FLOATING" >&2; exit 1; }
+
+        ADDRESS="$(hyprctl -j clients | jq -r '.[] | select(.class == "awtarchy-floating-check") | .address' | head -n1)"
+        hyprctl dispatch togglefloating "address:${ADDRESS}" >/dev/null
+        sleep 0.2
+        MANUAL_TILE="$(hyprctl -j clients | jq -r '.[] | select(.class == "awtarchy-floating-check") | .floating' | head -n1)"
+        [[ "$MANUAL_TILE" == false ]] || { printf 'Manual tiling did not override floating default: %s\n' "$MANUAL_TILE" >&2; exit 1; }
+
+        foot --app-id testgame.exe --title testgame.exe >/dev/null 2>&1 &
+        sleep 0.6
+        GAME_FLOAT="$(hyprctl -j clients | jq -r '.[] | select(.class == "testgame.exe") | .floating' | head -n1)"
+        [[ "$GAME_FLOAT" == false ]] || { printf 'Game exception unexpectedly floating: %s\n' "$GAME_FLOAT" >&2; exit 1; }
+
+        hyprctl -j clients >"$OUT/floating-clients.json"
+        [[ "$($helper set off)" == disabled ]]
+        hyprctl configerrors >"$OUT/configerrors-after-floating.txt"
+        [[ ! -s "$OUT/configerrors-after-floating.txt" ]]
+        ;;
+esac
+
+# Fail on runtime-level QML/config loader errors, while retaining complete logs.
+if [[ -f "$HOME/.cache/awtarchy/quickshell.log" ]]; then
+    cp "$HOME/.cache/awtarchy/quickshell.log" "$OUT/quickshell.log"
+    if grep -Eiq 'QQmlApplicationEngine failed|QQmlComponent: Component is not ready|Type .* unavailable|module .* is not installed|SyntaxError:|ReferenceError:' "$OUT/quickshell.log"; then
+        printf '%s\n' 'Quickshell log contains a QML/runtime loader error.' >&2
+        grep -Ein 'QQmlApplicationEngine failed|QQmlComponent: Component is not ready|Type .* unavailable|module .* is not installed|SyntaxError:|ReferenceError:' "$OUT/quickshell.log" >&2 || true
+        exit 1
+    fi
+fi
+
+hyprctl configerrors >"$OUT/configerrors-final.txt"
+[[ ! -s "$OUT/configerrors-final.txt" ]]
+qs -c awtarchy ipc call control ping >/dev/null
+printf 'PASS: live headless Hyprland/Quickshell smoke test for %s\n' "$TARGET_REF"
+SESSION
+chmod 0755 /tmp/runtime-session.sh
+chown tester:tester /tmp/runtime-session.sh "$OUT"
+
+runuser -u tester -- env TARGET_REF="$TARGET_REF" OUT="$OUT" \
+    dbus-run-session -- /tmp/runtime-session.sh

--- a/.github/scripts/nested-cage-hyprland-runtime-proof.sh
+++ b/.github/scripts/nested-cage-hyprland-runtime-proof.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+TARGET_REF="${TARGET_REF:?TARGET_REF is required}"
+ARTIFACT_DIR="${ARTIFACT_DIR:-/artifacts}"
+SAFE_TARGET="${TARGET_REF//\//_}"
+OUT="${ARTIFACT_DIR}/${SAFE_TARGET}"
+mkdir -p "$OUT"
+
+pacman -Syu --noconfirm --needed \
+    hyprland quickshell jq python dbus mesa mesa-utils \
+    cage xorg-server-xvfb wayland-utils \
+    wl-clipboard cliphist grim foot \
+    xdg-utils util-linux procps-ng libnotify qt6-wayland ttf-dejavu \
+    >"$OUT/pacman.log" 2>&1
+
+id tester >/dev/null 2>&1 || useradd -m -u 1000 tester
+install -d -m 0700 -o tester -g tester /run/user/1000
+install -d -o tester -g tester /home/tester/.config /home/tester/.cache
+rm -rf /home/tester/.config/hypr /home/tester/.config/quickshell
+cp -a /repo/config/hypr /home/tester/.config/hypr
+cp -a /repo/config/quickshell /home/tester/.config/quickshell
+chown -R tester:tester /home/tester/.config /home/tester/.cache
+find /home/tester/.config/hypr/scripts -type f -name '*.sh' -exec chmod u+x {} +
+
+cat > /tmp/cage-runtime-session.sh <<'SESSION'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+TARGET_REF="${TARGET_REF:?}"
+OUT="${OUT:?}"
+export HOME=/home/tester
+export XDG_CONFIG_HOME="$HOME/.config"
+export XDG_CACHE_HOME="$HOME/.cache"
+export XDG_RUNTIME_DIR=/run/user/1000
+export XDG_SESSION_TYPE=wayland
+export XDG_CURRENT_DESKTOP=Hyprland
+export HYPRLAND_NO_SD_VARS=1
+export HYPRLAND_NO_RT=1
+export LIBGL_ALWAYS_SOFTWARE=1
+export WLR_RENDERER_ALLOW_SOFTWARE=1
+export AQ_NO_KMS_REQUIREMENT=1
+export AQ_NO_MODIFIERS=1
+export AQ_TRACE=1
+export QT_QPA_PLATFORM=wayland
+
+XVFB_LOG="$OUT/xvfb.log"
+CAGE_LOG="$OUT/cage.log"
+HYPR_LOG="$OUT/hyprland.log"
+QS_LOG="$OUT/quickshell-manager.log"
+SOCKET_FILE="$XDG_RUNTIME_DIR/awtarchy-cage-socket-name"
+: >"$XVFB_LOG"
+: >"$CAGE_LOG"
+: >"$HYPR_LOG"
+: >"$QS_LOG"
+rm -f -- "$SOCKET_FILE"
+
+XVFB_PID=""
+CAGE_PID=""
+HYPR_PID=""
+cleanup() {
+    qs -c awtarchy ipc call control quit >/dev/null 2>&1 || true
+    if [[ -n "$HYPR_PID" ]]; then
+        kill "$HYPR_PID" >/dev/null 2>&1 || true
+        wait "$HYPR_PID" >/dev/null 2>&1 || true
+    fi
+    if [[ -n "$CAGE_PID" ]]; then
+        kill "$CAGE_PID" >/dev/null 2>&1 || true
+        wait "$CAGE_PID" >/dev/null 2>&1 || true
+    fi
+    if [[ -n "$XVFB_PID" ]]; then
+        kill "$XVFB_PID" >/dev/null 2>&1 || true
+        wait "$XVFB_PID" >/dev/null 2>&1 || true
+    fi
+}
+trap cleanup EXIT
+
+export DISPLAY=:99
+unset WAYLAND_DISPLAY
+Xvfb "$DISPLAY" -screen 0 1920x1080x24 -nolisten tcp >"$XVFB_LOG" 2>&1 &
+XVFB_PID=$!
+for _ in $(seq 1 120); do
+    [[ -S /tmp/.X11-unix/X99 ]] && break
+    if ! kill -0 "$XVFB_PID" 2>/dev/null; then
+        printf '%s\n' 'Xvfb exited before creating its X11 socket.' >&2
+        cat "$XVFB_LOG" >&2
+        exit 1
+    fi
+    sleep 0.1
+done
+[[ -S /tmp/.X11-unix/X99 ]] || {
+    printf '%s\n' 'Timed out waiting for Xvfb.' >&2
+    cat "$XVFB_LOG" >&2
+    exit 1
+}
+
+# WAYLAND_DISPLAY is deliberately unset for Cage so wlroots selects its X11
+# backend from DISPLAY. Cage then publishes the server socket name to its child.
+env -u WAYLAND_DISPLAY \
+    DISPLAY="$DISPLAY" \
+    LIBGL_ALWAYS_SOFTWARE=1 \
+    WLR_RENDERER_ALLOW_SOFTWARE=1 \
+    cage -D -x -- sh -c \
+        'printf "%s\n" "$WAYLAND_DISPLAY" >"$XDG_RUNTIME_DIR/awtarchy-cage-socket-name"; exec sleep 300' \
+        >"$CAGE_LOG" 2>&1 &
+CAGE_PID=$!
+
+CAGE_SOCKET=""
+for _ in $(seq 1 160); do
+    if [[ -s "$SOCKET_FILE" ]]; then
+        CAGE_SOCKET="$(cat "$SOCKET_FILE")"
+        [[ -S "$XDG_RUNTIME_DIR/$CAGE_SOCKET" ]] && break
+    fi
+    if ! kill -0 "$CAGE_PID" 2>/dev/null; then
+        printf '%s\n' 'Cage exited before publishing its Wayland socket.' >&2
+        cat "$CAGE_LOG" >&2
+        exit 1
+    fi
+    sleep 0.1
+done
+[[ -n "$CAGE_SOCKET" && -S "$XDG_RUNTIME_DIR/$CAGE_SOCKET" ]] || {
+    printf '%s\n' 'Timed out waiting for Cage Wayland socket.' >&2
+    cat "$CAGE_LOG" >&2
+    exit 1
+}
+
+WAYLAND_DISPLAY="$CAGE_SOCKET" wayland-info >"$OUT/outer-wayland-info.txt" 2>&1 || {
+    printf '%s\n' 'wayland-info could not inspect Cage.' >&2
+    cat "$OUT/outer-wayland-info.txt" >&2
+    exit 1
+}
+
+for required in wl_shm wl_seat xdg_wm_base zwp_linux_dmabuf_v1; do
+    if ! grep -Fq -- "$required" "$OUT/outer-wayland-info.txt"; then
+        printf 'Outer Cage compositor is missing required Wayland global: %s\n' "$required" >&2
+        cat "$OUT/outer-wayland-info.txt" >&2
+        exit 1
+    fi
+done
+
+seat_version="$(sed -n "s/.*interface: 'wl_seat'.*version:[[:space:]]*\([0-9][0-9]*\).*/\1/p" "$OUT/outer-wayland-info.txt" | head -n1)"
+xdg_version="$(sed -n "s/.*interface: 'xdg_wm_base'.*version:[[:space:]]*\([0-9][0-9]*\).*/\1/p" "$OUT/outer-wayland-info.txt" | head -n1)"
+printf 'cage-socket=%s\nwl-seat-version=%s\nxdg-wm-base-version=%s\n' \
+    "$CAGE_SOCKET" "$seat_version" "$xdg_version" >"$OUT/backend-mode.txt"
+
+export WAYLAND_DISPLAY="$CAGE_SOCKET"
+unset AQ_DRM_DEVICES
+{
+    printf '%s\n' '=== environment before Hyprland ==='
+    printf 'DISPLAY=%s\n' "$DISPLAY"
+    printf 'WAYLAND_DISPLAY=%s\n' "$WAYLAND_DISPLAY"
+    printf 'LIBGL_ALWAYS_SOFTWARE=%s\n' "$LIBGL_ALWAYS_SOFTWARE"
+    printf '%s\n' '=== eglinfo ==='
+    eglinfo -B 2>&1 || true
+} >"$OUT/render-environment.txt"
+
+Hyprland --config "$HOME/.config/hypr/hyprland.lua" >"$HYPR_LOG" 2>&1 &
+HYPR_PID=$!
+
+LOCK=""
+for _ in $(seq 1 180); do
+    LOCK="$(find "$XDG_RUNTIME_DIR/hypr" -mindepth 2 -maxdepth 2 -name hyprland.lock -print -quit 2>/dev/null || true)"
+    [[ -n "$LOCK" ]] && break
+    if ! kill -0 "$HYPR_PID" 2>/dev/null; then
+        printf '%s\n' 'Hyprland exited before creating a runtime lock.' >&2
+        cat "$HYPR_LOG" >&2
+        printf '%s\n' '=== Cage ===' >&2
+        cat "$CAGE_LOG" >&2
+        exit 1
+    fi
+    sleep 0.1
+done
+[[ -n "$LOCK" ]] || {
+    printf '%s\n' 'Timed out waiting for Hyprland runtime lock.' >&2
+    cat "$HYPR_LOG" >&2
+    exit 1
+}
+
+export HYPRLAND_INSTANCE_SIGNATURE="$(basename "$(dirname "$LOCK")")"
+export WAYLAND_DISPLAY="$(sed -n '2p' "$LOCK")"
+printf '%s\n' "$HYPRLAND_INSTANCE_SIGNATURE" >"$OUT/hyprland-instance.txt"
+printf '%s\n' "$WAYLAND_DISPLAY" >"$OUT/hyprland-wayland-display.txt"
+
+for _ in $(seq 1 120); do
+    if hyprctl -j monitors >"$OUT/monitors.json" 2>/dev/null && \
+        jq -e 'length > 0' "$OUT/monitors.json" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 0.1
+done
+jq -e 'length > 0' "$OUT/monitors.json" >/dev/null || {
+    printf '%s\n' 'Hyprland started but never exposed a monitor.' >&2
+    cat "$HYPR_LOG" >&2
+    exit 1
+}
+
+hyprctl configerrors >"$OUT/configerrors-initial.txt"
+[[ ! -s "$OUT/configerrors-initial.txt" ]] || {
+    printf '%s\n' 'Hyprland reported configuration errors:' >&2
+    cat "$OUT/configerrors-initial.txt" >&2
+    exit 1
+}
+
+"$HOME/.config/hypr/scripts/quickshell.sh" start >"$QS_LOG" 2>&1 || {
+    cat "$QS_LOG" >&2
+    [[ -f "$HOME/.cache/awtarchy/quickshell.log" ]] && cat "$HOME/.cache/awtarchy/quickshell.log" >&2
+    exit 1
+}
+
+QS_READY=0
+for _ in $(seq 1 180); do
+    if qs -c awtarchy ipc call control ping >/dev/null 2>&1; then
+        QS_READY=1
+        break
+    fi
+    sleep 0.1
+done
+(( QS_READY == 1 )) || {
+    printf '%s\n' 'Quickshell did not become IPC-ready.' >&2
+    [[ -f "$HOME/.cache/awtarchy/quickshell.log" ]] && cat "$HOME/.cache/awtarchy/quickshell.log" >&2
+    exit 1
+}
+
+qs -c awtarchy list --json >"$OUT/quickshell-instances.json"
+hyprctl -j layers >"$OUT/layers-before.json"
+"$HOME/.config/hypr/scripts/quickshell_quick_settings_toggle.sh"
+sleep 1
+qs -c awtarchy ipc call control ping >/dev/null
+hyprctl -j layers >"$OUT/layers-quicksettings.json"
+
+jq -e '[.. | objects | select((.namespace? // "") | contains("awtarchy"))] | length > 0' \
+    "$OUT/layers-quicksettings.json" >/dev/null 2>&1 || true
+
+grim "$OUT/quicksettings.png" >/dev/null 2>&1 || true
+"$HOME/.config/hypr/scripts/quickshell_quick_settings_toggle.sh"
+
+if [[ -f "$HOME/.cache/awtarchy/quickshell.log" ]]; then
+    cp "$HOME/.cache/awtarchy/quickshell.log" "$OUT/quickshell.log"
+    if grep -Eiq 'QQmlApplicationEngine failed|QQmlComponent: Component is not ready|Type .* unavailable|module .* is not installed|SyntaxError:|ReferenceError:' "$OUT/quickshell.log"; then
+        printf '%s\n' 'Quickshell log contains a QML/runtime loader error.' >&2
+        grep -Ein 'QQmlApplicationEngine failed|QQmlComponent: Component is not ready|Type .* unavailable|module .* is not installed|SyntaxError:|ReferenceError:' "$OUT/quickshell.log" >&2 || true
+        exit 1
+    fi
+fi
+
+hyprctl configerrors >"$OUT/configerrors-final.txt"
+[[ ! -s "$OUT/configerrors-final.txt" ]]
+qs -c awtarchy ipc call control ping >/dev/null
+printf 'PASS: Xvfb -> Cage -> Hyprland -> Quickshell runtime proof for %s\n' "$TARGET_REF"
+SESSION
+chmod 0755 /tmp/cage-runtime-session.sh
+chown tester:tester /tmp/cage-runtime-session.sh "$OUT"
+
+runuser -u tester -- env \
+    TARGET_REF="$TARGET_REF" \
+    OUT="$OUT" \
+    dbus-run-session -- /tmp/cage-runtime-session.sh

--- a/.github/scripts/nested-cage-hyprland-runtime-proof.sh
+++ b/.github/scripts/nested-cage-hyprland-runtime-proof.sh
@@ -9,7 +9,7 @@ mkdir -p "$OUT"
 
 pacman -Syu --noconfirm --needed \
     hyprland quickshell jq python dbus mesa mesa-utils \
-    cage xorg-server-xvfb wayland-utils \
+    cage xorg-server-xvfb xorg-xwayland wayland-utils \
     wl-clipboard cliphist grim foot \
     xdg-utils util-linux procps-ng libnotify qt6-wayland ttf-dejavu \
     >"$OUT/pacman.log" 2>&1
@@ -96,11 +96,13 @@ done
 
 # WAYLAND_DISPLAY is deliberately unset for Cage so wlroots selects its X11
 # backend from DISPLAY. Cage then publishes the server socket name to its child.
+# Do not depend on Cage's newer -x option: the Arch package available to CI may
+# lag the upstream CLI, so XWayland is installed and allowed to initialize.
 env -u WAYLAND_DISPLAY \
     DISPLAY="$DISPLAY" \
     LIBGL_ALWAYS_SOFTWARE=1 \
     WLR_RENDERER_ALLOW_SOFTWARE=1 \
-    cage -D -x -- sh -c \
+    cage -D -- sh -c \
         'printf "%s\n" "$WAYLAND_DISPLAY" >"$XDG_RUNTIME_DIR/awtarchy-cage-socket-name"; exec sleep 300' \
         >"$CAGE_LOG" 2>&1 &
 CAGE_PID=$!

--- a/.github/scripts/nested-cage-hyprland-runtime-proof.sh
+++ b/.github/scripts/nested-cage-hyprland-runtime-proof.sh
@@ -59,7 +59,7 @@ XVFB_PID=""
 CAGE_PID=""
 HYPR_PID=""
 cleanup() {
-    qs -c awtarchy ipc call control quit >/dev/null 2>&1 || true
+    timeout 2 qs -c awtarchy ipc call control quit >/dev/null 2>&1 || true
     if [[ -n "$HYPR_PID" ]]; then
         kill "$HYPR_PID" >/dev/null 2>&1 || true
         wait "$HYPR_PID" >/dev/null 2>&1 || true
@@ -126,7 +126,7 @@ done
     exit 1
 }
 
-WAYLAND_DISPLAY="$CAGE_SOCKET" wayland-info >"$OUT/outer-wayland-info.txt" 2>&1 || {
+WAYLAND_DISPLAY="$CAGE_SOCKET" timeout 8 wayland-info >"$OUT/outer-wayland-info.txt" 2>&1 || {
     printf '%s\n' 'wayland-info could not inspect Cage.' >&2
     cat "$OUT/outer-wayland-info.txt" >&2
     exit 1
@@ -153,7 +153,7 @@ unset AQ_DRM_DEVICES
     printf 'WAYLAND_DISPLAY=%s\n' "$WAYLAND_DISPLAY"
     printf 'LIBGL_ALWAYS_SOFTWARE=%s\n' "$LIBGL_ALWAYS_SOFTWARE"
     printf '%s\n' '=== eglinfo ==='
-    eglinfo -B 2>&1 || true
+    timeout 8 eglinfo -B 2>&1 || true
 } >"$OUT/render-environment.txt"
 
 Hyprland --config "$HOME/.config/hypr/hyprland.lua" >"$HYPR_LOG" 2>&1 &
@@ -184,7 +184,7 @@ printf '%s\n' "$HYPRLAND_INSTANCE_SIGNATURE" >"$OUT/hyprland-instance.txt"
 printf '%s\n' "$WAYLAND_DISPLAY" >"$OUT/hyprland-wayland-display.txt"
 
 for _ in $(seq 1 120); do
-    if hyprctl -j monitors >"$OUT/monitors.json" 2>/dev/null && \
+    if timeout 3 hyprctl -j monitors >"$OUT/monitors.json" 2>/dev/null && \
         jq -e 'length > 0' "$OUT/monitors.json" >/dev/null 2>&1; then
         break
     fi
@@ -196,14 +196,14 @@ jq -e 'length > 0' "$OUT/monitors.json" >/dev/null || {
     exit 1
 }
 
-hyprctl configerrors >"$OUT/configerrors-initial.txt"
+timeout 5 hyprctl configerrors >"$OUT/configerrors-initial.txt"
 [[ ! -s "$OUT/configerrors-initial.txt" ]] || {
     printf '%s\n' 'Hyprland reported configuration errors:' >&2
     cat "$OUT/configerrors-initial.txt" >&2
     exit 1
 }
 
-"$HOME/.config/hypr/scripts/quickshell.sh" start >"$QS_LOG" 2>&1 || {
+timeout 12 "$HOME/.config/hypr/scripts/quickshell.sh" start >"$QS_LOG" 2>&1 || {
     cat "$QS_LOG" >&2
     [[ -f "$HOME/.cache/awtarchy/quickshell.log" ]] && cat "$HOME/.cache/awtarchy/quickshell.log" >&2
     exit 1
@@ -211,7 +211,7 @@ hyprctl configerrors >"$OUT/configerrors-initial.txt"
 
 QS_READY=0
 for _ in $(seq 1 180); do
-    if qs -c awtarchy ipc call control ping >/dev/null 2>&1; then
+    if timeout 2 qs -c awtarchy ipc call control ping >/dev/null 2>&1; then
         QS_READY=1
         break
     fi
@@ -223,18 +223,21 @@ done
     exit 1
 }
 
-qs -c awtarchy list --json >"$OUT/quickshell-instances.json"
-hyprctl -j layers >"$OUT/layers-before.json"
-"$HOME/.config/hypr/scripts/quickshell_quick_settings_toggle.sh"
+timeout 5 qs -c awtarchy list --json >"$OUT/quickshell-instances.json"
+timeout 5 hyprctl -j layers >"$OUT/layers-before.json"
+timeout 5 "$HOME/.config/hypr/scripts/quickshell_quick_settings_toggle.sh"
 sleep 1
-qs -c awtarchy ipc call control ping >/dev/null
-hyprctl -j layers >"$OUT/layers-quicksettings.json"
+timeout 2 qs -c awtarchy ipc call control ping >/dev/null
+timeout 5 hyprctl -j layers >"$OUT/layers-quicksettings.json"
 
 jq -e '[.. | objects | select((.namespace? // "") | contains("awtarchy"))] | length > 0' \
     "$OUT/layers-quicksettings.json" >/dev/null 2>&1 || true
 
-grim "$OUT/quicksettings.png" >/dev/null 2>&1 || true
-"$HOME/.config/hypr/scripts/quickshell_quick_settings_toggle.sh"
+# Nested Aquamarine currently has a frame-presentation regression that can make
+# screencopy clients wait forever. A screenshot is diagnostic evidence, not a
+# reason to hang the runtime validation job.
+timeout 5 grim "$OUT/quicksettings.png" >/dev/null 2>&1 || true
+timeout 5 "$HOME/.config/hypr/scripts/quickshell_quick_settings_toggle.sh"
 
 if [[ -f "$HOME/.cache/awtarchy/quickshell.log" ]]; then
     cp "$HOME/.cache/awtarchy/quickshell.log" "$OUT/quickshell.log"
@@ -245,9 +248,9 @@ if [[ -f "$HOME/.cache/awtarchy/quickshell.log" ]]; then
     fi
 fi
 
-hyprctl configerrors >"$OUT/configerrors-final.txt"
+timeout 5 hyprctl configerrors >"$OUT/configerrors-final.txt"
 [[ ! -s "$OUT/configerrors-final.txt" ]]
-qs -c awtarchy ipc call control ping >/dev/null
+timeout 2 qs -c awtarchy ipc call control ping >/dev/null
 printf 'PASS: Xvfb -> Cage -> Hyprland -> Quickshell runtime proof for %s\n' "$TARGET_REF"
 SESSION
 chmod 0755 /tmp/cage-runtime-session.sh

--- a/.github/scripts/qemu-arch-hyprland-runtime-proof.sh
+++ b/.github/scripts/qemu-arch-hyprland-runtime-proof.sh
@@ -20,6 +20,7 @@ QEMU_LOG="$ARTIFACT_DIR/qemu-host.log"
 QEMU_PID_FILE="$WORK_DIR/qemu.pid"
 USER_DATA="$WORK_DIR/user-data"
 META_DATA="$WORK_DIR/meta-data"
+FAILURE_CONTEXT="$ARTIFACT_DIR/failure-context.txt"
 
 cleanup() {
     if [[ -f "$QEMU_PID_FILE" ]]; then
@@ -58,7 +59,7 @@ qemu-img resize -q "$GUEST_IMAGE" 16G
 ssh-keygen -q -t ed25519 -N '' -f "$SSH_KEY"
 PUBLIC_KEY="$(cat "${SSH_KEY}.pub")"
 
-cat >"$USER_DATA" <<EOF
+cat >"$USER_DATA" <<EOF_CLOUD
 #cloud-config
 users:
   - name: arch
@@ -75,17 +76,18 @@ growpart:
   mode: auto
   devices: ['/']
 resize_rootfs: true
-EOF
+EOF_CLOUD
 
-cat >"$META_DATA" <<'EOF'
+cat >"$META_DATA" <<'EOF_META'
 instance-id: awtarchy-qemu-runtime
 local-hostname: awtarchy-runtime
-EOF
+EOF_META
 
 cloud-localds "$SEED_IMAGE" "$USER_DATA" "$META_DATA"
 
 : >"$SERIAL_LOG"
 : >"$QEMU_LOG"
+: >"$FAILURE_CONTEXT"
 
 printf '%s\n' 'Starting QEMU Arch guest with virtio-gpu 2D device...'
 qemu-system-x86_64 \
@@ -120,6 +122,70 @@ vm_ssh() {
     ssh "${SSH_OPTS[@]}" arch@127.0.0.1 "$@"
 }
 
+qemu_alive() {
+    local qemu_pid=""
+    [[ -f "$QEMU_PID_FILE" ]] || return 1
+    qemu_pid="$(cat "$QEMU_PID_FILE" 2>/dev/null || true)"
+    [[ -n "$qemu_pid" ]] && kill -0 "$qemu_pid" 2>/dev/null
+}
+
+collect_failure_evidence() {
+    local stage="$1"
+    local guest_probe="$WORK_DIR/guest-failure-probe.txt"
+
+    {
+        printf 'stage=%s\n' "$stage"
+        date -u '+utc=%Y-%m-%dT%H:%M:%SZ'
+        if qemu_alive; then
+            printf 'qemu_alive=yes\n'
+            ps -o pid,ppid,stat,etime,cmd -p "$(cat "$QEMU_PID_FILE")" 2>&1 || true
+        else
+            printf 'qemu_alive=no\n'
+        fi
+        printf '%s\n' '=== qemu host log ==='
+        cat "$QEMU_LOG" 2>&1 || true
+        printf '%s\n' '=== serial tail ==='
+        tail -n 300 "$SERIAL_LOG" 2>&1 || true
+    } >>"$FAILURE_CONTEXT" 2>&1
+
+    if vm_ssh 'set +e
+        mkdir -p /tmp/awtarchy-vm
+        {
+            echo "=== guest failure probe ==="
+            date -u
+            uname -a
+            id
+            echo "=== uptime ==="
+            uptime
+            echo "=== processes ==="
+            ps -ef | grep -E "Hyprland|dbus-run-session|seatd" | grep -v grep
+            echo "=== hypr runtime ==="
+            find /run/user/1000/hypr -maxdepth 3 -type f -o -type s 2>/dev/null
+            echo "=== dri ==="
+            ls -la /dev/dri 2>/dev/null
+            echo "=== input ==="
+            ls -la /dev/input 2>/dev/null
+            echo "=== seatd ==="
+            systemctl --no-pager --full status seatd.service
+            echo "=== kernel tail ==="
+            sudo dmesg | tail -n 200
+            echo "=== hyprland log ==="
+            tail -n 300 /tmp/awtarchy-vm/hyprland.log 2>/dev/null
+        } >/tmp/awtarchy-vm/failure-probe.txt 2>&1
+        cp /tmp/awtarchy-vm/hyprland.log /tmp/awtarchy-vm/hyprland-failure.log 2>/dev/null
+        exit 0' >"$guest_probe" 2>&1; then
+        cat "$guest_probe" >>"$FAILURE_CONTEXT" 2>&1 || true
+        scp "${SCP_OPTS[@]}" -r \
+            arch@127.0.0.1:/tmp/awtarchy-vm/. \
+            "$ARTIFACT_DIR/" >/dev/null 2>&1 || true
+    else
+        {
+            printf '%s\n' '=== guest SSH failure ==='
+            cat "$guest_probe" 2>&1 || true
+        } >>"$FAILURE_CONTEXT"
+    fi
+}
+
 printf '%s\n' 'Waiting for SSH/cloud-init...'
 ssh_ready=0
 for _ in $(seq 1 150); do
@@ -127,19 +193,16 @@ for _ in $(seq 1 150); do
         ssh_ready=1
         break
     fi
-    if [[ -f "$QEMU_PID_FILE" ]]; then
-        qemu_pid="$(cat "$QEMU_PID_FILE")"
-        if ! kill -0 "$qemu_pid" 2>/dev/null; then
-            printf '%s\n' 'QEMU exited before SSH became available.' >&2
-            tail -n 200 "$SERIAL_LOG" >&2 || true
-            exit 1
-        fi
+    if ! qemu_alive; then
+        printf '%s\n' 'QEMU exited before SSH became available.' >&2
+        collect_failure_evidence 'qemu-exited-before-ssh'
+        exit 1
     fi
     sleep 2
 done
 (( ssh_ready == 1 )) || {
     printf '%s\n' 'Timed out waiting for the Arch guest SSH service.' >&2
-    tail -n 200 "$SERIAL_LOG" >&2 || true
+    collect_failure_evidence 'ssh-timeout'
     exit 1
 }
 
@@ -154,8 +217,6 @@ tar -C . -czf - config/hypr config/quickshell \
     | ssh "${SSH_OPTS[@]}" arch@127.0.0.1 \
         'rm -rf ~/.config/hypr ~/.config/quickshell; mkdir -p ~/.config; tar -C ~ -xzf -; cp -a ~/config/hypr ~/.config/hypr; cp -a ~/config/quickshell ~/.config/quickshell; rm -rf ~/config'
 
-# Open a fresh SSH login after group membership changed so the runtime user has
-# the seat/video/render/input supplementary groups.
 vm_ssh 'id; test -S /run/seatd.sock; test -r ~/.config/hypr/hyprland.lua'
 
 vm_ssh 'mkdir -p /tmp/awtarchy-vm; {
@@ -168,10 +229,18 @@ vm_ssh 'mkdir -p /tmp/awtarchy-vm; {
         printf "%s: " "$node";
         udevadm info --query=property --name="$node" 2>/dev/null | grep -E "^(DRIVER|ID_PATH|DEVNAME)=" || true;
     done;
+    echo "=== /dev/input ==="; ls -la /dev/input || true;
     echo "=== modules ==="; lsmod | grep -E "virtio_gpu|drm" || true;
+    echo "=== seatd ==="; systemctl --no-pager --full status seatd.service || true;
 } >/tmp/awtarchy-vm/hardware.txt 2>&1'
-
 vm_ssh 'timeout 15 eglinfo -B >/tmp/awtarchy-vm/eglinfo.txt 2>&1 || true'
+
+# Preserve pre-Hyprland evidence immediately. If compositor startup crashes or
+# disconnects the guest, the GPU/seat/input baseline still reaches the artifact.
+scp "${SCP_OPTS[@]}" \
+    arch@127.0.0.1:/tmp/awtarchy-vm/hardware.txt \
+    arch@127.0.0.1:/tmp/awtarchy-vm/eglinfo.txt \
+    "$ARTIFACT_DIR/" >/dev/null 2>&1 || true
 
 cat >"$WORK_DIR/start-hyprland.sh" <<'GUEST'
 #!/usr/bin/env bash
@@ -203,17 +272,19 @@ for _ in $(seq 1 60); do
         hypr_ready=1
         break
     fi
-    if ! vm_ssh 'pid=$(cat /tmp/awtarchy-vm/hyprland.pid 2>/dev/null || true); test -n "$pid" && kill -0 "$pid" 2>/dev/null' >/dev/null 2>&1; then
+    if ! qemu_alive; then
+        printf '%s\n' 'QEMU exited while Hyprland was starting.' >&2
+        break
+    fi
+    if ! vm_ssh 'pgrep -x Hyprland >/dev/null 2>&1 || pgrep -f "Hyprland --config" >/dev/null 2>&1' >/dev/null 2>&1; then
         printf '%s\n' 'Hyprland exited before exposing a monitor in the QEMU guest.' >&2
-        vm_ssh 'tail -n 250 /tmp/awtarchy-vm/hyprland.log' >&2 || true
         break
     fi
     sleep 1
 done
 
 if (( hypr_ready == 0 )); then
-    vm_ssh 'cp /tmp/awtarchy-vm/hyprland.log /tmp/awtarchy-vm/hyprland-failure.log 2>/dev/null || true'
-    scp "${SCP_OPTS[@]}" -r arch@127.0.0.1:/tmp/awtarchy-vm/. "$ARTIFACT_DIR/" >/dev/null 2>&1 || true
+    collect_failure_evidence 'hyprland-not-ready'
     printf '%s\n' 'QEMU guest did not reach a usable Hyprland monitor.' >&2
     exit 1
 fi
@@ -233,8 +304,7 @@ for _ in $(seq 1 60); do
 done
 
 if (( qs_ready == 0 )); then
-    vm_ssh 'cp ~/.cache/awtarchy/quickshell.log /tmp/awtarchy-vm/quickshell.log 2>/dev/null || true'
-    scp "${SCP_OPTS[@]}" -r arch@127.0.0.1:/tmp/awtarchy-vm/. "$ARTIFACT_DIR/" >/dev/null 2>&1 || true
+    collect_failure_evidence 'quickshell-not-ready'
     printf '%s\n' 'Quickshell did not become IPC-ready in the QEMU guest.' >&2
     exit 1
 fi

--- a/.github/scripts/qemu-arch-hyprland-runtime-proof.sh
+++ b/.github/scripts/qemu-arch-hyprland-runtime-proof.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+TARGET_REF="${TARGET_REF:?TARGET_REF is required}"
+ARTIFACT_DIR="${ARTIFACT_DIR:-runtime-artifacts}"
+WORK_DIR="${RUNNER_TEMP:-/tmp}/awtarchy-qemu-runtime"
+SSH_PORT="${SSH_PORT:-2222}"
+ARCH_IMAGE_URL="${ARCH_IMAGE_URL:-https://fastly.mirror.pkgbuild.com/images/latest/Arch-Linux-x86_64-cloudimg.qcow2}"
+
+rm -rf -- "$WORK_DIR"
+mkdir -p "$WORK_DIR" "$ARTIFACT_DIR"
+
+BASE_IMAGE="$WORK_DIR/Arch-Linux-x86_64-cloudimg.qcow2"
+CHECKSUM_FILE="$WORK_DIR/Arch-Linux-x86_64-cloudimg.qcow2.SHA256"
+GUEST_IMAGE="$WORK_DIR/guest.qcow2"
+SEED_IMAGE="$WORK_DIR/seed.img"
+SSH_KEY="$WORK_DIR/id_ed25519"
+SERIAL_LOG="$ARTIFACT_DIR/qemu-serial.log"
+QEMU_LOG="$ARTIFACT_DIR/qemu-host.log"
+QEMU_PID_FILE="$WORK_DIR/qemu.pid"
+USER_DATA="$WORK_DIR/user-data"
+META_DATA="$WORK_DIR/meta-data"
+
+cleanup() {
+    if [[ -f "$QEMU_PID_FILE" ]]; then
+        qemu_pid="$(cat "$QEMU_PID_FILE" 2>/dev/null || true)"
+        if [[ -n "$qemu_pid" ]] && kill -0 "$qemu_pid" 2>/dev/null; then
+            kill "$qemu_pid" >/dev/null 2>&1 || true
+            for _ in $(seq 1 30); do
+                kill -0 "$qemu_pid" 2>/dev/null || break
+                sleep 0.2
+            done
+            kill -KILL "$qemu_pid" >/dev/null 2>&1 || true
+        fi
+    fi
+}
+trap cleanup EXIT
+
+for command_name in curl qemu-img qemu-system-x86_64 cloud-localds ssh scp ssh-keygen tar; do
+    command -v "$command_name" >/dev/null 2>&1 || {
+        printf 'Missing host dependency: %s\n' "$command_name" >&2
+        exit 1
+    }
+done
+
+printf '%s\n' 'Downloading current official Arch Linux cloud image...'
+curl --fail --location --retry 3 --retry-delay 2 \
+    "$ARCH_IMAGE_URL" -o "$BASE_IMAGE"
+curl --fail --location --retry 3 --retry-delay 2 \
+    "${ARCH_IMAGE_URL}.SHA256" -o "$CHECKSUM_FILE"
+(
+    cd "$WORK_DIR"
+    sha256sum --check "$(basename "$CHECKSUM_FILE")"
+)
+
+qemu-img create -q -f qcow2 -F qcow2 -b "$BASE_IMAGE" "$GUEST_IMAGE"
+qemu-img resize -q "$GUEST_IMAGE" 16G
+ssh-keygen -q -t ed25519 -N '' -f "$SSH_KEY"
+PUBLIC_KEY="$(cat "${SSH_KEY}.pub")"
+
+cat >"$USER_DATA" <<EOF
+#cloud-config
+users:
+  - name: arch
+    gecos: Awtarchy Runtime Test
+    groups: [wheel]
+    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+    shell: /bin/bash
+    lock_passwd: true
+    ssh_authorized_keys:
+      - ${PUBLIC_KEY}
+disable_root: true
+ssh_pwauth: false
+growpart:
+  mode: auto
+  devices: ['/']
+resize_rootfs: true
+EOF
+
+cat >"$META_DATA" <<'EOF'
+instance-id: awtarchy-qemu-runtime
+local-hostname: awtarchy-runtime
+EOF
+
+cloud-localds "$SEED_IMAGE" "$USER_DATA" "$META_DATA"
+
+: >"$SERIAL_LOG"
+: >"$QEMU_LOG"
+
+printf '%s\n' 'Starting QEMU Arch guest with virtio-gpu 2D device...'
+qemu-system-x86_64 \
+    -name awtarchy-runtime \
+    -machine q35,accel=tcg \
+    -cpu max \
+    -smp 4 \
+    -m 4096 \
+    -drive "if=virtio,file=${GUEST_IMAGE},format=qcow2" \
+    -drive "if=virtio,file=${SEED_IMAGE},format=raw,readonly=on" \
+    -device virtio-vga,max_outputs=1 \
+    -display none \
+    -serial "file:${SERIAL_LOG}" \
+    -netdev "user,id=net0,hostfwd=tcp:127.0.0.1:${SSH_PORT}-:22" \
+    -device virtio-net-pci,netdev=net0 \
+    -pidfile "$QEMU_PID_FILE" \
+    -daemonize \
+    >>"$QEMU_LOG" 2>&1
+
+SSH_OPTS=(
+    -i "$SSH_KEY"
+    -p "$SSH_PORT"
+    -o StrictHostKeyChecking=no
+    -o UserKnownHostsFile=/dev/null
+    -o ConnectTimeout=4
+    -o ServerAliveInterval=5
+    -o ServerAliveCountMax=2
+)
+
+vm_ssh() {
+    ssh "${SSH_OPTS[@]}" arch@127.0.0.1 "$@"
+}
+
+printf '%s\n' 'Waiting for SSH/cloud-init...'
+ssh_ready=0
+for _ in $(seq 1 150); do
+    if vm_ssh 'true' >/dev/null 2>&1; then
+        ssh_ready=1
+        break
+    fi
+    if [[ -f "$QEMU_PID_FILE" ]]; then
+        qemu_pid="$(cat "$QEMU_PID_FILE")"
+        if ! kill -0 "$qemu_pid" 2>/dev/null; then
+            printf '%s\n' 'QEMU exited before SSH became available.' >&2
+            tail -n 200 "$SERIAL_LOG" >&2 || true
+            exit 1
+        fi
+    fi
+    sleep 2
+done
+(( ssh_ready == 1 )) || {
+    printf '%s\n' 'Timed out waiting for the Arch guest SSH service.' >&2
+    tail -n 200 "$SERIAL_LOG" >&2 || true
+    exit 1
+}
+
+vm_ssh 'cloud-init status --wait >/dev/null 2>&1 || true'
+
+printf '%s\n' 'Installing runtime packages inside the real Arch guest...'
+vm_ssh 'sudo pacman -Syu --noconfirm --needed hyprland quickshell mesa mesa-utils seatd jq dbus wl-clipboard cliphist grim foot qt6-wayland ttf-dejavu procps-ng >/tmp/awtarchy-pacman.log 2>&1'
+vm_ssh 'sudo systemctl enable --now seatd.service; sudo usermod -aG seat,video,render,input arch; sudo install -d -o arch -g arch -m 0700 /run/user/1000'
+
+printf '%s\n' 'Copying exact feature-branch Awtarchy config into the guest...'
+tar -C . -czf - config/hypr config/quickshell \
+    | ssh "${SSH_OPTS[@]}" arch@127.0.0.1 \
+        'rm -rf ~/.config/hypr ~/.config/quickshell; mkdir -p ~/.config; tar -C ~ -xzf -; cp -a ~/config/hypr ~/.config/hypr; cp -a ~/config/quickshell ~/.config/quickshell; rm -rf ~/config'
+
+# Open a fresh SSH login after group membership changed so the runtime user has
+# the seat/video/render/input supplementary groups.
+vm_ssh 'id; test -S /run/seatd.sock; test -r ~/.config/hypr/hyprland.lua'
+
+vm_ssh 'mkdir -p /tmp/awtarchy-vm; {
+    echo "=== uname ==="; uname -a;
+    echo "=== groups ==="; id;
+    echo "=== /dev/dri ==="; ls -la /dev/dri || true;
+    echo "=== DRM drivers ===";
+    for node in /dev/dri/card* /dev/dri/renderD*; do
+        test -e "$node" || continue;
+        printf "%s: " "$node";
+        udevadm info --query=property --name="$node" 2>/dev/null | grep -E "^(DRIVER|ID_PATH|DEVNAME)=" || true;
+    done;
+    echo "=== modules ==="; lsmod | grep -E "virtio_gpu|drm" || true;
+} >/tmp/awtarchy-vm/hardware.txt 2>&1'
+
+vm_ssh 'timeout 15 eglinfo -B >/tmp/awtarchy-vm/eglinfo.txt 2>&1 || true'
+
+cat >"$WORK_DIR/start-hyprland.sh" <<'GUEST'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+export HOME=/home/arch
+export XDG_CONFIG_HOME="$HOME/.config"
+export XDG_CACHE_HOME="$HOME/.cache"
+export XDG_RUNTIME_DIR=/run/user/1000
+export XDG_SESSION_TYPE=wayland
+export XDG_CURRENT_DESKTOP=Hyprland
+export XDG_SESSION_DESKTOP=Hyprland
+export LIBSEAT_BACKEND=seatd
+export SEATD_VTBOUND=0
+export AQ_TRACE=1
+export AQ_NO_MODIFIERS=1
+export HYPRLAND_NO_RT=1
+export HYPRLAND_NO_SD_VARS=1
+mkdir -p "$XDG_CACHE_HOME"
+exec dbus-run-session -- Hyprland --config "$HOME/.config/hypr/hyprland.lua"
+GUEST
+
+scp "${SSH_OPTS[@]}" "$WORK_DIR/start-hyprland.sh" arch@127.0.0.1:/tmp/start-hyprland.sh >/dev/null
+vm_ssh 'chmod 0755 /tmp/start-hyprland.sh; rm -rf /run/user/1000/hypr; setsid /tmp/start-hyprland.sh >/tmp/awtarchy-vm/hyprland.log 2>&1 </dev/null & echo $! >/tmp/awtarchy-vm/hyprland.pid'
+
+printf '%s\n' 'Waiting for Hyprland inside the QEMU guest...'
+hypr_ready=0
+for _ in $(seq 1 60); do
+    if vm_ssh 'lock=$(find /run/user/1000/hypr -mindepth 2 -maxdepth 2 -name hyprland.lock -print -quit 2>/dev/null); test -n "$lock" || exit 1; export HYPRLAND_INSTANCE_SIGNATURE=$(basename "$(dirname "$lock")"); timeout 3 hyprctl -j monitors | jq -e "length > 0" >/dev/null' >/dev/null 2>&1; then
+        hypr_ready=1
+        break
+    fi
+    if ! vm_ssh 'pid=$(cat /tmp/awtarchy-vm/hyprland.pid 2>/dev/null || true); test -n "$pid" && kill -0 "$pid" 2>/dev/null' >/dev/null 2>&1; then
+        printf '%s\n' 'Hyprland exited before exposing a monitor in the QEMU guest.' >&2
+        vm_ssh 'tail -n 250 /tmp/awtarchy-vm/hyprland.log' >&2 || true
+        break
+    fi
+    sleep 1
+done
+
+if (( hypr_ready == 0 )); then
+    vm_ssh 'cp /tmp/awtarchy-vm/hyprland.log /tmp/awtarchy-vm/hyprland-failure.log 2>/dev/null || true'
+    scp "${SSH_OPTS[@]}" -r arch@127.0.0.1:/tmp/awtarchy-vm/. "$ARTIFACT_DIR/" >/dev/null 2>&1 || true
+    printf '%s\n' 'QEMU guest did not reach a usable Hyprland monitor.' >&2
+    exit 1
+fi
+
+vm_ssh 'lock=$(find /run/user/1000/hypr -mindepth 2 -maxdepth 2 -name hyprland.lock -print -quit); export HYPRLAND_INSTANCE_SIGNATURE=$(basename "$(dirname "$lock")"); export WAYLAND_DISPLAY=$(sed -n "2p" "$lock"); export XDG_RUNTIME_DIR=/run/user/1000; hyprctl -j monitors >/tmp/awtarchy-vm/monitors.json; hyprctl configerrors >/tmp/awtarchy-vm/configerrors-initial.txt; test ! -s /tmp/awtarchy-vm/configerrors-initial.txt'
+
+printf '%s\n' 'Starting Awtarchy Quickshell inside the QEMU guest...'
+vm_ssh 'lock=$(find /run/user/1000/hypr -mindepth 2 -maxdepth 2 -name hyprland.lock -print -quit); export HYPRLAND_INSTANCE_SIGNATURE=$(basename "$(dirname "$lock")"); export WAYLAND_DISPLAY=$(sed -n "2p" "$lock"); export XDG_RUNTIME_DIR=/run/user/1000; export XDG_CONFIG_HOME=$HOME/.config; export XDG_CACHE_HOME=$HOME/.cache; ~/.config/hypr/scripts/quickshell.sh start >/tmp/awtarchy-vm/quickshell-manager.log 2>&1 || true'
+
+qs_ready=0
+for _ in $(seq 1 60); do
+    if vm_ssh 'lock=$(find /run/user/1000/hypr -mindepth 2 -maxdepth 2 -name hyprland.lock -print -quit); export HYPRLAND_INSTANCE_SIGNATURE=$(basename "$(dirname "$lock")"); export WAYLAND_DISPLAY=$(sed -n "2p" "$lock"); export XDG_RUNTIME_DIR=/run/user/1000; timeout 2 qs -c awtarchy ipc call control ping >/dev/null' >/dev/null 2>&1; then
+        qs_ready=1
+        break
+    fi
+    sleep 1
+done
+
+if (( qs_ready == 0 )); then
+    vm_ssh 'cp ~/.cache/awtarchy/quickshell.log /tmp/awtarchy-vm/quickshell.log 2>/dev/null || true'
+    scp "${SSH_OPTS[@]}" -r arch@127.0.0.1:/tmp/awtarchy-vm/. "$ARTIFACT_DIR/" >/dev/null 2>&1 || true
+    printf '%s\n' 'Quickshell did not become IPC-ready in the QEMU guest.' >&2
+    exit 1
+fi
+
+vm_ssh 'lock=$(find /run/user/1000/hypr -mindepth 2 -maxdepth 2 -name hyprland.lock -print -quit); export HYPRLAND_INSTANCE_SIGNATURE=$(basename "$(dirname "$lock")"); export WAYLAND_DISPLAY=$(sed -n "2p" "$lock"); export XDG_RUNTIME_DIR=/run/user/1000; export XDG_CONFIG_HOME=$HOME/.config; export XDG_CACHE_HOME=$HOME/.cache; timeout 5 ~/.config/hypr/scripts/quickshell_quick_settings_toggle.sh; sleep 1; timeout 5 qs -c awtarchy ipc call control ping >/dev/null; hyprctl -j layers >/tmp/awtarchy-vm/layers-quicksettings.json; timeout 5 grim /tmp/awtarchy-vm/quicksettings.png >/dev/null 2>&1 || true; cp ~/.cache/awtarchy/quickshell.log /tmp/awtarchy-vm/quickshell.log 2>/dev/null || true; hyprctl configerrors >/tmp/awtarchy-vm/configerrors-final.txt; test ! -s /tmp/awtarchy-vm/configerrors-final.txt'
+
+vm_ssh 'if test -f /tmp/awtarchy-vm/quickshell.log && grep -Eiq "QQmlApplicationEngine failed|QQmlComponent: Component is not ready|Type .* unavailable|module .* is not installed|SyntaxError:|ReferenceError:" /tmp/awtarchy-vm/quickshell.log; then grep -Ein "QQmlApplicationEngine failed|QQmlComponent: Component is not ready|Type .* unavailable|module .* is not installed|SyntaxError:|ReferenceError:" /tmp/awtarchy-vm/quickshell.log >&2; exit 1; fi'
+
+scp "${SSH_OPTS[@]}" -r arch@127.0.0.1:/tmp/awtarchy-vm/. "$ARTIFACT_DIR/" >/dev/null
+printf 'PASS: real QEMU Arch guest reached Hyprland + Awtarchy Quickshell runtime for %s\n' "$TARGET_REF"

--- a/.github/scripts/qemu-arch-hyprland-runtime-proof.sh
+++ b/.github/scripts/qemu-arch-hyprland-runtime-proof.sh
@@ -105,15 +105,16 @@ qemu-system-x86_64 \
     -daemonize \
     >>"$QEMU_LOG" 2>&1
 
-SSH_OPTS=(
+SSH_COMMON_OPTS=(
     -i "$SSH_KEY"
-    -p "$SSH_PORT"
     -o StrictHostKeyChecking=no
     -o UserKnownHostsFile=/dev/null
     -o ConnectTimeout=4
     -o ServerAliveInterval=5
     -o ServerAliveCountMax=2
 )
+SSH_OPTS=("${SSH_COMMON_OPTS[@]}" -p "$SSH_PORT")
+SCP_OPTS=("${SSH_COMMON_OPTS[@]}" -P "$SSH_PORT")
 
 vm_ssh() {
     ssh "${SSH_OPTS[@]}" arch@127.0.0.1 "$@"
@@ -142,7 +143,7 @@ done
     exit 1
 }
 
-vm_ssh 'cloud-init status --wait >/dev/null 2>&1 || true'
+vm_ssh 'timeout 90 cloud-init status --wait >/dev/null 2>&1 || true'
 
 printf '%s\n' 'Installing runtime packages inside the real Arch guest...'
 vm_ssh 'sudo pacman -Syu --noconfirm --needed hyprland quickshell mesa mesa-utils seatd jq dbus wl-clipboard cliphist grim foot qt6-wayland ttf-dejavu procps-ng >/tmp/awtarchy-pacman.log 2>&1'
@@ -192,7 +193,7 @@ mkdir -p "$XDG_CACHE_HOME"
 exec dbus-run-session -- Hyprland --config "$HOME/.config/hypr/hyprland.lua"
 GUEST
 
-scp "${SSH_OPTS[@]}" "$WORK_DIR/start-hyprland.sh" arch@127.0.0.1:/tmp/start-hyprland.sh >/dev/null
+scp "${SCP_OPTS[@]}" "$WORK_DIR/start-hyprland.sh" arch@127.0.0.1:/tmp/start-hyprland.sh >/dev/null
 vm_ssh 'chmod 0755 /tmp/start-hyprland.sh; rm -rf /run/user/1000/hypr; setsid /tmp/start-hyprland.sh >/tmp/awtarchy-vm/hyprland.log 2>&1 </dev/null & echo $! >/tmp/awtarchy-vm/hyprland.pid'
 
 printf '%s\n' 'Waiting for Hyprland inside the QEMU guest...'
@@ -212,7 +213,7 @@ done
 
 if (( hypr_ready == 0 )); then
     vm_ssh 'cp /tmp/awtarchy-vm/hyprland.log /tmp/awtarchy-vm/hyprland-failure.log 2>/dev/null || true'
-    scp "${SSH_OPTS[@]}" -r arch@127.0.0.1:/tmp/awtarchy-vm/. "$ARTIFACT_DIR/" >/dev/null 2>&1 || true
+    scp "${SCP_OPTS[@]}" -r arch@127.0.0.1:/tmp/awtarchy-vm/. "$ARTIFACT_DIR/" >/dev/null 2>&1 || true
     printf '%s\n' 'QEMU guest did not reach a usable Hyprland monitor.' >&2
     exit 1
 fi
@@ -233,7 +234,7 @@ done
 
 if (( qs_ready == 0 )); then
     vm_ssh 'cp ~/.cache/awtarchy/quickshell.log /tmp/awtarchy-vm/quickshell.log 2>/dev/null || true'
-    scp "${SSH_OPTS[@]}" -r arch@127.0.0.1:/tmp/awtarchy-vm/. "$ARTIFACT_DIR/" >/dev/null 2>&1 || true
+    scp "${SCP_OPTS[@]}" -r arch@127.0.0.1:/tmp/awtarchy-vm/. "$ARTIFACT_DIR/" >/dev/null 2>&1 || true
     printf '%s\n' 'Quickshell did not become IPC-ready in the QEMU guest.' >&2
     exit 1
 fi
@@ -242,5 +243,5 @@ vm_ssh 'lock=$(find /run/user/1000/hypr -mindepth 2 -maxdepth 2 -name hyprland.l
 
 vm_ssh 'if test -f /tmp/awtarchy-vm/quickshell.log && grep -Eiq "QQmlApplicationEngine failed|QQmlComponent: Component is not ready|Type .* unavailable|module .* is not installed|SyntaxError:|ReferenceError:" /tmp/awtarchy-vm/quickshell.log; then grep -Ein "QQmlApplicationEngine failed|QQmlComponent: Component is not ready|Type .* unavailable|module .* is not installed|SyntaxError:|ReferenceError:" /tmp/awtarchy-vm/quickshell.log >&2; exit 1; fi'
 
-scp "${SSH_OPTS[@]}" -r arch@127.0.0.1:/tmp/awtarchy-vm/. "$ARTIFACT_DIR/" >/dev/null
+scp "${SCP_OPTS[@]}" -r arch@127.0.0.1:/tmp/awtarchy-vm/. "$ARTIFACT_DIR/" >/dev/null
 printf 'PASS: real QEMU Arch guest reached Hyprland + Awtarchy Quickshell runtime for %s\n' "$TARGET_REF"

--- a/.github/workflows/test-headless-quickshell-runtime.yml
+++ b/.github/workflows/test-headless-quickshell-runtime.yml
@@ -1,0 +1,104 @@
+name: Test Headless Hyprland Quickshell Runtime
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/test-headless-quickshell-runtime.yml'
+      - '.github/scripts/headless-quickshell-runtime-smoke.sh'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  merge-compatibility:
+    name: Synthetic merge compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          fetch-depth: 0
+      - name: Merge feature branches in release order
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          refs=(
+            feature/progressive-clipboard-loading
+            feature/focused-display-scale
+            feature/quick-settings-layout-customization
+            feature/floating-windows-default
+          )
+          git fetch origin \
+            '+refs/heads/feature/progressive-clipboard-loading:refs/remotes/origin/feature/progressive-clipboard-loading' \
+            '+refs/heads/feature/focused-display-scale:refs/remotes/origin/feature/focused-display-scale' \
+            '+refs/heads/feature/quick-settings-layout-customization:refs/remotes/origin/feature/quick-settings-layout-customization' \
+            '+refs/heads/feature/floating-windows-default:refs/remotes/origin/feature/floating-windows-default' \
+            '+refs/heads/main:refs/remotes/origin/main'
+          git switch --detach origin/main
+          git config user.name 'Awtarchy Runtime Test'
+          git config user.email 'runtime-test@invalid.local'
+          for ref in "${refs[@]}"; do
+            printf '\n=== merging %s ===\n' "$ref"
+            if ! git merge --no-edit --no-ff "origin/${ref}"; then
+              printf '\nConflicted paths:\n' >&2
+              git diff --name-only --diff-filter=U >&2 || true
+              git status --short >&2 || true
+              exit 1
+            fi
+          done
+          git diff --check origin/main..HEAD
+
+  headless-runtime:
+    name: Headless runtime - ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: clipboard
+            ref: feature/progressive-clipboard-loading
+          - name: display-scale
+            ref: feature/focused-display-scale
+          - name: quick-settings-layout
+            ref: feature/quick-settings-layout-customization
+          - name: floating-windows
+            ref: feature/floating-windows-default
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          fetch-depth: 0
+      - name: Preserve harness and check out exact feature head
+        shell: bash
+        env:
+          TARGET_REF: ${{ matrix.ref }}
+        run: |
+          set -Eeuo pipefail
+          cp .github/scripts/headless-quickshell-runtime-smoke.sh /tmp/headless-quickshell-runtime-smoke.sh
+          chmod 0755 /tmp/headless-quickshell-runtime-smoke.sh
+          git fetch origin "+refs/heads/${TARGET_REF}:refs/remotes/origin/${TARGET_REF}"
+          git switch --detach "origin/${TARGET_REF}"
+          printf 'Target: %s\n' "$TARGET_REF"
+          git rev-parse HEAD
+      - name: Run live Hyprland and Quickshell in Arch container
+        shell: bash
+        env:
+          TARGET_REF: ${{ matrix.ref }}
+        run: |
+          set -Eeuo pipefail
+          mkdir -p runtime-artifacts
+          docker run --rm --privileged \
+            -e TARGET_REF="$TARGET_REF" \
+            -e ARTIFACT_DIR=/artifacts \
+            -v "$PWD:/repo:ro" \
+            -v "/tmp/headless-quickshell-runtime-smoke.sh:/runtime-smoke.sh:ro" \
+            -v "$PWD/runtime-artifacts:/artifacts" \
+            archlinux:base-devel \
+            bash /runtime-smoke.sh
+      - name: Upload runtime evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: headless-runtime-${{ matrix.name }}
+          path: runtime-artifacts/
+          if-no-files-found: warn
+          retention-days: 3

--- a/.github/workflows/test-headless-quickshell-runtime.yml
+++ b/.github/workflows/test-headless-quickshell-runtime.yml
@@ -74,20 +74,8 @@ jobs:
           git diff --check origin/main..HEAD
 
   headless-runtime:
-    name: Headless runtime - ${{ matrix.name }}
+    name: Headless runtime backend proof
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: clipboard
-            ref: feature/progressive-clipboard-loading
-          - name: display-scale
-            ref: feature/focused-display-scale
-          - name: quick-settings-layout
-            ref: feature/quick-settings-layout-customization
-          - name: floating-windows
-            ref: feature/floating-windows-default
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
@@ -95,7 +83,7 @@ jobs:
       - name: Preserve harness and check out exact feature head
         shell: bash
         env:
-          TARGET_REF: ${{ matrix.ref }}
+          TARGET_REF: feature/quick-settings-layout-customization
         run: |
           set -Eeuo pipefail
           cp .github/scripts/headless-quickshell-runtime-smoke.sh /tmp/headless-quickshell-runtime-smoke.sh
@@ -104,49 +92,66 @@ jobs:
           git switch --detach "origin/${TARGET_REF}"
           printf 'Target: %s\n' "$TARGET_REF"
           git rev-parse HEAD
-      - name: Prepare software virtual DRM
+      - name: Prepare VGEM software virtual DRM
         shell: bash
         run: |
           set -Eeuo pipefail
-          printf '%s\n' 'Attempting VGEM virtual render device...'
-          if sudo modprobe vgem; then
-            printf '%s\n' 'VGEM loaded.'
-          else
-            printf '%s\n' 'VGEM unavailable; runtime harness will try nested Weston.'
+          before="${RUNNER_TEMP}/dri-before"
+          after="${RUNNER_TEMP}/dri-after"
+          find /dev/dri -maxdepth 1 -type c -name 'card*' -print 2>/dev/null | sort >"$before" || true
+
+          if ! sudo modprobe vgem 2>/dev/null; then
+            printf '%s\n' 'VGEM is not in the runner base module set; installing matching Azure extra modules.'
+            sudo apt-get update
+            sudo apt-get install -y "linux-modules-extra-$(uname -r)"
+            sudo modprobe vgem
           fi
-          ls -la /dev/dri 2>/dev/null || true
-          for node in /dev/dri/card* /dev/dri/renderD*; do
-            [[ -e "$node" ]] || continue
-            udevadm info --query=property --name="$node" 2>/dev/null \
-              | grep -E '^(DEVNAME|DRIVER|ID_PATH|ID_MODEL)=' || true
-          done
+
+          find /dev/dri -maxdepth 1 -type c -name 'card*' -print 2>/dev/null | sort >"$after" || true
+          VGEM_CARD="$(comm -13 "$before" "$after" | head -n1)"
+
+          if [[ -z "$VGEM_CARD" ]]; then
+            for node in /dev/dri/card*; do
+              [[ -e "$node" ]] || continue
+              name="$(basename "$node")"
+              driver="$(basename "$(readlink -f "/sys/class/drm/${name}/device/driver" 2>/dev/null)" 2>/dev/null || true)"
+              if [[ "$driver" == vgem ]]; then
+                VGEM_CARD="$node"
+                break
+              fi
+            done
+          fi
+
+          [[ -n "$VGEM_CARD" && -e "$VGEM_CARD" ]] || {
+            printf '%s\n' 'VGEM loaded but its DRM card could not be identified.' >&2
+            ls -la /dev/dri >&2 || true
+            exit 1
+          }
+
+          printf 'VGEM_CARD=%s\n' "$VGEM_CARD" | tee -a "$GITHUB_ENV"
+          ls -la /dev/dri
+          udevadm info --query=all --name="$VGEM_CARD" || true
       - name: Run live Hyprland and Quickshell in Arch container
         shell: bash
         env:
-          TARGET_REF: ${{ matrix.ref }}
+          TARGET_REF: feature/quick-settings-layout-customization
         run: |
           set -Eeuo pipefail
           mkdir -p runtime-artifacts
-          docker_args=(
-            --rm
-            --privileged
-            -e "TARGET_REF=${TARGET_REF}"
-            -e ARTIFACT_DIR=/artifacts
-            -v "$PWD:/repo:ro"
-            -v "/tmp/headless-quickshell-runtime-smoke.sh:/runtime-smoke.sh:ro"
-            -v "$PWD/runtime-artifacts:/artifacts"
-          )
-          if [[ -d /dev/dri ]]; then
-            docker_args+=( -v /dev/dri:/dev/dri )
-          fi
-          docker run "${docker_args[@]}" \
+          docker run --rm \
+            --device "$VGEM_CARD:$VGEM_CARD" \
+            -e "TARGET_REF=${TARGET_REF}" \
+            -e ARTIFACT_DIR=/artifacts \
+            -v "$PWD:/repo:ro" \
+            -v "/tmp/headless-quickshell-runtime-smoke.sh:/runtime-smoke.sh:ro" \
+            -v "$PWD/runtime-artifacts:/artifacts" \
             archlinux:base-devel \
-            bash /runtime-smoke.sh
+            bash -lc 'chmod a+rw /dev/dri/card* 2>/dev/null || true; exec bash /runtime-smoke.sh'
       - name: Upload runtime evidence
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: headless-runtime-${{ matrix.name }}
+          name: headless-runtime-backend-proof
           path: runtime-artifacts/
           if-no-files-found: warn
           retention-days: 3

--- a/.github/workflows/test-headless-quickshell-runtime.yml
+++ b/.github/workflows/test-headless-quickshell-runtime.yml
@@ -22,6 +22,7 @@ jobs:
         shell: bash
         run: |
           set -Eeuo pipefail
+          history='local/share/awtarchy/quickshell-managed-history.sha256'
           refs=(
             feature/progressive-clipboard-loading
             feature/focused-display-scale
@@ -37,15 +38,39 @@ jobs:
           git switch --detach origin/main
           git config user.name 'Awtarchy Runtime Test'
           git config user.email 'runtime-test@invalid.local'
+
           for ref in "${refs[@]}"; do
             printf '\n=== merging %s ===\n' "$ref"
-            if ! git merge --no-edit --no-ff "origin/${ref}"; then
-              printf '\nConflicted paths:\n' >&2
-              git diff --name-only --diff-filter=U >&2 || true
-              git status --short >&2 || true
-              exit 1
+            if git merge --no-edit --no-ff "origin/${ref}"; then
+              continue
             fi
+
+            mapfile -t conflicts < <(git diff --name-only --diff-filter=U)
+            printf 'Conflicted paths:\n' >&2
+            printf '  %s\n' "${conflicts[@]}" >&2
+
+            # Every feature branch appends its own known-stock hashes to the same
+            # cumulative migration file. Resolve only that mechanically safe
+            # append-only collision; any production/source conflict remains fatal.
+            if [[ ${#conflicts[@]} -eq 1 && ${conflicts[0]} == "$history" ]]; then
+              git show ":2:${history}" >"${RUNNER_TEMP}/history-ours"
+              git show ":3:${history}" >"${RUNNER_TEMP}/history-theirs"
+              cp "${RUNNER_TEMP}/history-ours" "$history"
+              while IFS= read -r line || [[ -n "$line" ]]; do
+                if ! grep -Fqx -- "$line" "$history"; then
+                  printf '%s\n' "$line" >>"$history"
+                fi
+              done <"${RUNNER_TEMP}/history-theirs"
+              git add -- "$history"
+              git diff --check --cached
+              git commit --no-edit
+              continue
+            fi
+
+            git status --short >&2 || true
+            exit 1
           done
+
           git diff --check origin/main..HEAD
 
   headless-runtime:
@@ -79,6 +104,22 @@ jobs:
           git switch --detach "origin/${TARGET_REF}"
           printf 'Target: %s\n' "$TARGET_REF"
           git rev-parse HEAD
+      - name: Prepare software virtual DRM
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          printf '%s\n' 'Attempting VGEM virtual render device...'
+          if sudo modprobe vgem; then
+            printf '%s\n' 'VGEM loaded.'
+          else
+            printf '%s\n' 'VGEM unavailable; runtime harness will try nested Weston.'
+          fi
+          ls -la /dev/dri 2>/dev/null || true
+          for node in /dev/dri/card* /dev/dri/renderD*; do
+            [[ -e "$node" ]] || continue
+            udevadm info --query=property --name="$node" 2>/dev/null \
+              | grep -E '^(DEVNAME|DRIVER|ID_PATH|ID_MODEL)=' || true
+          done
       - name: Run live Hyprland and Quickshell in Arch container
         shell: bash
         env:
@@ -86,12 +127,19 @@ jobs:
         run: |
           set -Eeuo pipefail
           mkdir -p runtime-artifacts
-          docker run --rm --privileged \
-            -e TARGET_REF="$TARGET_REF" \
-            -e ARTIFACT_DIR=/artifacts \
-            -v "$PWD:/repo:ro" \
-            -v "/tmp/headless-quickshell-runtime-smoke.sh:/runtime-smoke.sh:ro" \
-            -v "$PWD/runtime-artifacts:/artifacts" \
+          docker_args=(
+            --rm
+            --privileged
+            -e "TARGET_REF=${TARGET_REF}"
+            -e ARTIFACT_DIR=/artifacts
+            -v "$PWD:/repo:ro"
+            -v "/tmp/headless-quickshell-runtime-smoke.sh:/runtime-smoke.sh:ro"
+            -v "$PWD/runtime-artifacts:/artifacts"
+          )
+          if [[ -d /dev/dri ]]; then
+            docker_args+=( -v /dev/dri:/dev/dri )
+          fi
+          docker run "${docker_args[@]}" \
             archlinux:base-devel \
             bash /runtime-smoke.sh
       - name: Upload runtime evidence

--- a/.github/workflows/test-headless-quickshell-runtime.yml
+++ b/.github/workflows/test-headless-quickshell-runtime.yml
@@ -4,8 +4,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/test-headless-quickshell-runtime.yml'
-      - '.github/scripts/headless-quickshell-runtime-smoke.sh'
-      - '.github/scripts/nested-cage-hyprland-runtime-proof.sh'
+      - '.github/scripts/qemu-arch-hyprland-runtime-proof.sh'
   workflow_dispatch:
 
 permissions:
@@ -177,45 +176,46 @@ jobs:
 
           printf '%s\n' 'PASS: #72-#75 compose with only the intentional #74/#75 Quick Settings integration.'
 
-  headless-runtime:
-    name: Nested Cage runtime proof
+  qemu-runtime:
+    name: Real Arch QEMU runtime proof
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           fetch-depth: 0
+      - name: Install QEMU runtime tools
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86 qemu-utils cloud-image-utils openssh-client
       - name: Preserve harness and check out exact feature head
         shell: bash
         env:
           TARGET_REF: feature/quick-settings-layout-customization
         run: |
           set -Eeuo pipefail
-          cp .github/scripts/nested-cage-hyprland-runtime-proof.sh /tmp/nested-cage-hyprland-runtime-proof.sh
-          chmod 0755 /tmp/nested-cage-hyprland-runtime-proof.sh
+          cp .github/scripts/qemu-arch-hyprland-runtime-proof.sh /tmp/qemu-arch-hyprland-runtime-proof.sh
+          chmod 0755 /tmp/qemu-arch-hyprland-runtime-proof.sh
           git fetch origin "+refs/heads/${TARGET_REF}:refs/remotes/origin/${TARGET_REF}"
           git switch --detach "origin/${TARGET_REF}"
           printf 'Target: %s\n' "$TARGET_REF"
           git rev-parse HEAD
-      - name: Run Xvfb, Cage, Hyprland and Quickshell
+      - name: Boot Arch VM and run Hyprland plus Quickshell
         shell: bash
         env:
           TARGET_REF: feature/quick-settings-layout-customization
         run: |
           set -Eeuo pipefail
           mkdir -p runtime-artifacts
-          docker run --rm \
-            -e "TARGET_REF=${TARGET_REF}" \
-            -e ARTIFACT_DIR=/artifacts \
-            -v "$PWD:/repo:ro" \
-            -v "/tmp/nested-cage-hyprland-runtime-proof.sh:/runtime-proof.sh:ro" \
-            -v "$PWD/runtime-artifacts:/artifacts" \
-            archlinux:base-devel \
-            bash /runtime-proof.sh
+          timeout --signal=TERM --kill-after=20s 17m \
+            env TARGET_REF="$TARGET_REF" ARTIFACT_DIR="$PWD/runtime-artifacts" \
+            /tmp/qemu-arch-hyprland-runtime-proof.sh
       - name: Upload runtime evidence
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: nested-cage-runtime-proof
+          name: qemu-arch-runtime-proof
           path: runtime-artifacts/
           if-no-files-found: warn
           retention-days: 3

--- a/.github/workflows/test-headless-quickshell-runtime.yml
+++ b/.github/workflows/test-headless-quickshell-runtime.yml
@@ -18,26 +18,101 @@ jobs:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           fetch-depth: 0
-      - name: Merge feature branches in release order
+      - name: Compose all four feature branches and run combined tests
         shell: bash
         run: |
           set -Eeuo pipefail
+
           history='local/share/awtarchy/quickshell-managed-history.sha256'
+          quick_settings='config/quickshell/awtarchy/QuickSettings.qml'
           refs=(
             feature/progressive-clipboard-loading
             feature/focused-display-scale
             feature/quick-settings-layout-customization
             feature/floating-windows-default
           )
+
           git fetch origin \
             '+refs/heads/feature/progressive-clipboard-loading:refs/remotes/origin/feature/progressive-clipboard-loading' \
             '+refs/heads/feature/focused-display-scale:refs/remotes/origin/feature/focused-display-scale' \
             '+refs/heads/feature/quick-settings-layout-customization:refs/remotes/origin/feature/quick-settings-layout-customization' \
             '+refs/heads/feature/floating-windows-default:refs/remotes/origin/feature/floating-windows-default' \
             '+refs/heads/main:refs/remotes/origin/main'
+
           git switch --detach origin/main
-          git config user.name 'Awtarchy Runtime Test'
-          git config user.email 'runtime-test@invalid.local'
+          git config user.name 'Awtarchy Integration Test'
+          git config user.email 'integration-test@invalid.local'
+
+          resolve_history_conflict() {
+            local ours="${RUNNER_TEMP}/history-ours"
+            local theirs="${RUNNER_TEMP}/history-theirs"
+            git show ":2:${history}" >"$ours"
+            git show ":3:${history}" >"$theirs"
+            cp "$ours" "$history"
+            while IFS= read -r line || [[ -n "$line" ]]; do
+              if ! grep -Fqx -- "$line" "$history"; then
+                printf '%s\n' "$line" >>"$history"
+              fi
+            done <"$theirs"
+            git add -- "$history"
+          }
+
+          resolve_floating_layout_conflict() {
+            # #74 owns dynamic section ordering. #75 adds Floating Windows beside
+            # Title Bars. Compose them as one reorderable/show-hide window-behavior
+            # section instead of choosing either branch's version.
+            git show ":2:${quick_settings}" >"$quick_settings"
+            python3 - "$quick_settings" <<'PY'
+          from pathlib import Path
+          import sys
+
+          path = Path(sys.argv[1])
+          text = path.read_text()
+          old = '''              TitleBarsCard {
+                            Layout.row: root.quickSettingsSectionRow("title-bars")
+                            visible: root.quickSettingsSectionVisible("title-bars")
+                            active: quickSettingsWindow.visible
+                            textScale: root.effectiveTextScale
+                            iconScale: root.effectiveIconScale
+                        }
+          '''
+          new = '''              ColumnLayout {
+                            Layout.row: root.quickSettingsSectionRow("title-bars")
+                            visible: root.quickSettingsSectionVisible("title-bars")
+                            Layout.fillWidth: true
+                            spacing: 8
+
+                            TitleBarsCard {
+                                active: quickSettingsWindow.visible
+                                textScale: root.effectiveTextScale
+                                iconScale: root.effectiveIconScale
+                            }
+
+                            FloatingWindowsCard {
+                                active: quickSettingsWindow.visible
+                                textScale: root.effectiveTextScale
+                                iconScale: root.effectiveIconScale
+                            }
+                        }
+          '''
+          if text.count(old) != 1:
+              raise SystemExit('expected exactly one #74 TitleBarsCard block for integration composition')
+          path.write_text(text.replace(old, new, 1))
+          PY
+            git add -- "$quick_settings"
+
+            # The real eventual #74+#75 reconciliation needs the combined stock
+            # QuickSettings hash. Add it only to this synthetic tree so both
+            # updater-policy tests validate the composed state without changing
+            # either feature PR.
+            local digest
+            digest="$(sha256sum "$quick_settings" | awk '{print $1}')"
+            if ! grep -Fq -- "$digest"$'\t.config/quickshell/awtarchy/QuickSettings.qml' "$history"; then
+              printf '\n%s\n' '# synthetic CI hash for composed #74 + #75 QuickSettings.qml' >>"$history"
+              printf '%s\t%s\n' "$digest" '.config/quickshell/awtarchy/QuickSettings.qml' >>"$history"
+            fi
+            git add -- "$history"
+          }
 
           for ref in "${refs[@]}"; do
             printf '\n=== merging %s ===\n' "$ref"
@@ -49,32 +124,60 @@ jobs:
             printf 'Conflicted paths:\n' >&2
             printf '  %s\n' "${conflicts[@]}" >&2
 
-            # Every feature branch appends its own known-stock hashes to the same
-            # cumulative migration file. Resolve only that mechanically safe
-            # append-only collision; any production/source conflict remains fatal.
             if [[ ${#conflicts[@]} -eq 1 && ${conflicts[0]} == "$history" ]]; then
-              git show ":2:${history}" >"${RUNNER_TEMP}/history-ours"
-              git show ":3:${history}" >"${RUNNER_TEMP}/history-theirs"
-              cp "${RUNNER_TEMP}/history-ours" "$history"
-              while IFS= read -r line || [[ -n "$line" ]]; do
-                if ! grep -Fqx -- "$line" "$history"; then
-                  printf '%s\n' "$line" >>"$history"
-                fi
-              done <"${RUNNER_TEMP}/history-theirs"
-              git add -- "$history"
+              resolve_history_conflict
               git diff --check --cached
               git commit --no-edit
               continue
             fi
 
+            if [[ "$ref" == feature/floating-windows-default ]]; then
+              unexpected=0
+              have_history=0
+              have_quick=0
+              for path in "${conflicts[@]}"; do
+                case "$path" in
+                  "$history") have_history=1 ;;
+                  "$quick_settings") have_quick=1 ;;
+                  *) unexpected=1 ;;
+                esac
+              done
+              if (( unexpected == 0 && have_history == 1 && have_quick == 1 )); then
+                resolve_history_conflict
+                resolve_floating_layout_conflict
+                git diff --check --cached
+                git commit --no-edit
+                continue
+              fi
+            fi
+
+            printf '%s\n' 'Unexpected source conflict. Integration composition is not safe.' >&2
             git status --short >&2 || true
             exit 1
           done
 
+          test -z "$(git diff --name-only --diff-filter=U)"
           git diff --check origin/main..HEAD
 
+          tests=(
+            tests/test-quickshell-clipboard-load-state.sh
+            tests/test-quickshell-clipboard-progressive.sh
+            tests/test-quickshell-clipboard-thumbnails.sh
+            tests/test-display-scale-quicksettings.sh
+            tests/test-quick-settings-layout.sh
+            tests/test-floating-windows-quicksettings.sh
+            tests/test-flyout-edge-layout.sh
+          )
+          for test_file in "${tests[@]}"; do
+            printf '\n=== %s ===\n' "$test_file"
+            bash -n "$test_file"
+            bash "$test_file"
+          done
+
+          printf '%s\n' 'PASS: #72-#75 compose with only the intentional #74/#75 Quick Settings integration.'
+
   headless-runtime:
-    name: Headless runtime backend proof
+    name: Nested Weston GL runtime proof
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
@@ -92,46 +195,7 @@ jobs:
           git switch --detach "origin/${TARGET_REF}"
           printf 'Target: %s\n' "$TARGET_REF"
           git rev-parse HEAD
-      - name: Prepare VGEM software virtual DRM
-        shell: bash
-        run: |
-          set -Eeuo pipefail
-          before="${RUNNER_TEMP}/dri-before"
-          after="${RUNNER_TEMP}/dri-after"
-          find /dev/dri -maxdepth 1 -type c -name 'card*' -print 2>/dev/null | sort >"$before" || true
-
-          if ! sudo modprobe vgem 2>/dev/null; then
-            printf '%s\n' 'VGEM is not in the runner base module set; installing matching Azure extra modules.'
-            sudo apt-get update
-            sudo apt-get install -y "linux-modules-extra-$(uname -r)"
-            sudo modprobe vgem
-          fi
-
-          find /dev/dri -maxdepth 1 -type c -name 'card*' -print 2>/dev/null | sort >"$after" || true
-          VGEM_CARD="$(comm -13 "$before" "$after" | head -n1)"
-
-          if [[ -z "$VGEM_CARD" ]]; then
-            for node in /dev/dri/card*; do
-              [[ -e "$node" ]] || continue
-              name="$(basename "$node")"
-              driver="$(basename "$(readlink -f "/sys/class/drm/${name}/device/driver" 2>/dev/null)" 2>/dev/null || true)"
-              if [[ "$driver" == vgem ]]; then
-                VGEM_CARD="$node"
-                break
-              fi
-            done
-          fi
-
-          [[ -n "$VGEM_CARD" && -e "$VGEM_CARD" ]] || {
-            printf '%s\n' 'VGEM loaded but its DRM card could not be identified.' >&2
-            ls -la /dev/dri >&2 || true
-            exit 1
-          }
-
-          printf 'VGEM_CARD=%s\n' "$VGEM_CARD" | tee -a "$GITHUB_ENV"
-          ls -la /dev/dri
-          udevadm info --query=all --name="$VGEM_CARD" || true
-      - name: Run live Hyprland and Quickshell in Arch container
+      - name: Run nested software-rendered Hyprland and Quickshell
         shell: bash
         env:
           TARGET_REF: feature/quick-settings-layout-customization
@@ -139,19 +203,19 @@ jobs:
           set -Eeuo pipefail
           mkdir -p runtime-artifacts
           docker run --rm \
-            --device "$VGEM_CARD:$VGEM_CARD" \
             -e "TARGET_REF=${TARGET_REF}" \
             -e ARTIFACT_DIR=/artifacts \
+            -e FORCE_NESTED_WESTON=1 \
             -v "$PWD:/repo:ro" \
             -v "/tmp/headless-quickshell-runtime-smoke.sh:/runtime-smoke.sh:ro" \
             -v "$PWD/runtime-artifacts:/artifacts" \
             archlinux:base-devel \
-            bash -lc 'chmod a+rw /dev/dri/card* 2>/dev/null || true; exec bash /runtime-smoke.sh'
+            bash /runtime-smoke.sh
       - name: Upload runtime evidence
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: headless-runtime-backend-proof
+          name: nested-weston-gl-runtime-proof
           path: runtime-artifacts/
           if-no-files-found: warn
           retention-days: 3

--- a/.github/workflows/test-headless-quickshell-runtime.yml
+++ b/.github/workflows/test-headless-quickshell-runtime.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - '.github/workflows/test-headless-quickshell-runtime.yml'
       - '.github/scripts/headless-quickshell-runtime-smoke.sh'
+      - '.github/scripts/nested-cage-hyprland-runtime-proof.sh'
   workflow_dispatch:
 
 permissions:
@@ -177,7 +178,7 @@ jobs:
           printf '%s\n' 'PASS: #72-#75 compose with only the intentional #74/#75 Quick Settings integration.'
 
   headless-runtime:
-    name: Nested Weston GL runtime proof
+    name: Nested Cage runtime proof
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
@@ -189,13 +190,13 @@ jobs:
           TARGET_REF: feature/quick-settings-layout-customization
         run: |
           set -Eeuo pipefail
-          cp .github/scripts/headless-quickshell-runtime-smoke.sh /tmp/headless-quickshell-runtime-smoke.sh
-          chmod 0755 /tmp/headless-quickshell-runtime-smoke.sh
+          cp .github/scripts/nested-cage-hyprland-runtime-proof.sh /tmp/nested-cage-hyprland-runtime-proof.sh
+          chmod 0755 /tmp/nested-cage-hyprland-runtime-proof.sh
           git fetch origin "+refs/heads/${TARGET_REF}:refs/remotes/origin/${TARGET_REF}"
           git switch --detach "origin/${TARGET_REF}"
           printf 'Target: %s\n' "$TARGET_REF"
           git rev-parse HEAD
-      - name: Run nested software-rendered Hyprland and Quickshell
+      - name: Run Xvfb, Cage, Hyprland and Quickshell
         shell: bash
         env:
           TARGET_REF: feature/quick-settings-layout-customization
@@ -205,17 +206,16 @@ jobs:
           docker run --rm \
             -e "TARGET_REF=${TARGET_REF}" \
             -e ARTIFACT_DIR=/artifacts \
-            -e FORCE_NESTED_WESTON=1 \
             -v "$PWD:/repo:ro" \
-            -v "/tmp/headless-quickshell-runtime-smoke.sh:/runtime-smoke.sh:ro" \
+            -v "/tmp/nested-cage-hyprland-runtime-proof.sh:/runtime-proof.sh:ro" \
             -v "$PWD/runtime-artifacts:/artifacts" \
             archlinux:base-devel \
-            bash /runtime-smoke.sh
+            bash /runtime-proof.sh
       - name: Upload runtime evidence
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: nested-weston-gl-runtime-proof
+          name: nested-cage-runtime-proof
           path: runtime-artifacts/
           if-no-files-found: warn
           retention-days: 3


### PR DESCRIPTION
Disposable CI-only integration/runtime harness for pre-merge verification of PRs #72-#75.

Current coverage:

- synthetically composes #72 -> #73 -> #74 -> #75 and runs the focused regression suites together
- mechanically unions only the expected append-only `quickshell-managed-history.sha256` collisions
- verifies the known #74/#75 Quick Settings overlap using the intended combined Window Behavior section without changing either feature PR
- boots an official Arch Linux cloud image in a real QEMU guest with its own kernel and virtio GPU
- attempts to start the exact feature-branch Hyprland + Awtarchy Quickshell configuration inside that guest and uploads runtime evidence

Earlier direct-container, VGEM, Weston-headless, and Cage experiments established GitHub-host graphics/protocol limitations and are not considered feature failures.

Do not merge this PR. It exists only to develop and prove reusable runtime/integration validation before any CI is promoted into normal Awtarchy workflows.