### PR TITLE
Fix Bluetooth state sync and Night Light toggle

### DIFF
--- a/config/hypr/scripts/hyprsunset_ctl.sh
+++ b/config/hypr/scripts/hyprsunset_ctl.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/hyprsunset"
 OFFSET_FILE="$STATE_DIR/offset"       # offset from BASE_K (for compatibility + status)
 TEMP_FILE="$STATE_DIR/last_temp"      # last absolute temperature (K)
-ENABLED_FILE="$STATE_DIR/enabled"     # fallback when JSON/jq isn't available: 1=on, 0=off
+ENABLED_FILE="$STATE_DIR/enabled"     # fallback when live Hyprsunset state is unavailable: 1=on, 0=off
 SCHEDULE_FILE="$STATE_DIR/schedule"
 CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/hypr"
 CONFIG_FILE="$CONFIG_DIR/hyprsunset.conf"
@@ -38,8 +38,6 @@ notify() {
     notify-send -a "hyprsunset" -t 1400 "Night Light" "$msg" >/dev/null 2>&1 || true
   fi
 }
-
-have_jq() { command -v jq >/dev/null 2>&1; }
 
 read_int_file() {
   local file="$1" def="$2" v=""
@@ -268,17 +266,17 @@ enable_saved_schedule() {
   set_schedule "$SCHEDULE_START" "$SCHEDULE_END" "$SCHEDULE_TEMP"
 }
 
-# Best-effort: return "true" / "false" / "unknown"
+# Best-effort: return "true" / "false" / "unknown" from Hyprsunset IPC.
 get_identity_state() {
-  if have_jq && hyprctl -j hyprsunset >/dev/null 2>&1; then
-    # Some hyprctl -j outputs have a noisy prefix line; strip anything before the first '{'
-    local json
-    json="$(hyprctl -j hyprsunset 2>/dev/null | sed -n '0,/{/s/^[^{]*//;/{/,$p' || true)"
-    if [[ -n "$json" ]]; then
-      local v
-      v="$(jq -r '(.identity // "unknown")' <<<"$json" 2>/dev/null || true)"
-      [[ -n "$v" ]] && { printf '%s\n' "$v"; return 0; }
-    fi
+  local value=""
+  if command -v hyprctl >/dev/null 2>&1; then
+    value="$(hyprctl hyprsunset identity get 2>/dev/null | tr -d '\r\n' || true)"
+    case "$value" in
+      true|false)
+        printf '%s\n' "$value"
+        return 0
+        ;;
+    esac
   fi
   printf '%s\n' "unknown"
 }

--- a/config/quickshell/awtarchy/BluetoothMenu.qml
+++ b/config/quickshell/awtarchy/BluetoothMenu.qml
@@ -464,6 +464,7 @@ Singleton {
     function openForScreen(targetScreen) {
         if (!targetScreen || !available)
             return;
+        refreshActualAdapterPower();
         FlyoutManager.claim("bluetooth", targetScreen.name);
         flyoutScreen = targetScreen;
         if (!bluetoothWindow.visible)
@@ -526,15 +527,7 @@ Singleton {
 
     Connections {
         target: root.adapter
-        function onStateChanged() {
-            if (!root.adapter)
-                return;
-            if (root.adapter.state === BluetoothAdapterState.Enabled)
-                root.actualAdapterEnabled = 1;
-            else if (root.adapter.state === BluetoothAdapterState.Disabled
-                || root.adapter.state === BluetoothAdapterState.Blocked)
-                root.actualAdapterEnabled = 0;
-        }
+        function onStateChanged() { root.refreshActualAdapterPower(); }
     }
 
     Process {

--- a/local/share/awtarchy/quickshell-managed-history.sha256
+++ b/local/share/awtarchy/quickshell-managed-history.sha256
@@ -714,3 +714,7 @@ aa102596d1a39c055713d7ea920bce7585bf06daed8d327cec3767af9eed9c6e	.config/quicksh
 fc9d20e69385fc3da1586acd15b717655f06a47bebab1ad1d53fda573c65d120	.config/quickshell/awtarchy/Bar.qml
 6fc1df7c177cdb0597ff2c4f0cb098200f74c76dfc6a85229c49de99f00310a7	.config/hypr/scripts/quickshell_application_state.sh
 d8f56a516c35052a834d3c678012a7a71a4e083be86650d717a76e2ac5d7017b	.config/quickshell/awtarchy/QuickSettings.qml
+
+# 2026-08-28 Bluetooth live-state sync and Night Light toggle.
+1356d0609489d6aaeea014b3a97f8be8ac362fdbad8cb11a0c018c9d69250bc6	.config/quickshell/awtarchy/BluetoothMenu.qml
+37fa633153aacc055c7f0268491794f5b37fa622757e117fd2d96bfb815444fa	.config/hypr/scripts/hyprsunset_ctl.sh

--- a/tests/test-bluetooth-state-persistence.sh
+++ b/tests/test-bluetooth-state-persistence.sh
@@ -107,6 +107,21 @@ grep -Fq 'actualAdapterEnabled >= 0' "$MENU"
 grep -Fq 'bluetoothPowerProbe.exec([bluetoothStateScript, "actual"])' "$MENU"
 grep -Fq 'id: bluetoothPowerProbe' "$MENU"
 grep -Fq 'stdout: StdioCollector' "$MENU"
+
+open_block="$(sed -n '/function openForScreen(targetScreen)/,/^    }/p' "$MENU")"
+grep -Fq 'refreshActualAdapterPower();' <<<"$open_block" || {
+    printf '%s\n' 'Bluetooth flyout does not refresh the authoritative BlueZ power state when opened.' >&2
+    exit 1
+}
+grep -Fq 'function onStateChanged() { root.refreshActualAdapterPower(); }' "$MENU" || {
+    printf '%s\n' 'Quickshell adapter state changes do not re-probe the authoritative BlueZ power state.' >&2
+    exit 1
+}
+if grep -Fq 'if (root.adapter.state === BluetoothAdapterState.Enabled)' "$MENU"; then
+    printf '%s\n' 'Bluetooth UI can overwrite the probed BlueZ power state with stale Quickshell adapter state.' >&2
+    exit 1
+fi
+
 grep -Fq 'signal.pidfd_send_signal(pidfd, signal.SIGTERM)' "$MANAGER"
 if grep -Fq 'signal.SIGKILL' "$MANAGER" || grep -Fq 'kill -KILL' "$MANAGER"; then
     printf '%s\n' 'Quickshell updater still contains a SIGKILL fallback.' >&2

--- a/tests/test-night-light-schedule.sh
+++ b/tests/test-night-light-schedule.sh
@@ -22,12 +22,56 @@ trap 'rm -rf -- "$TMPD"' EXIT
 export HOME="${TMPD}/home"
 export XDG_CONFIG_HOME="${HOME}/.config"
 export XDG_STATE_HOME="${HOME}/.local/state"
-mkdir -p -- "$XDG_CONFIG_HOME" "$XDG_STATE_HOME"
+mkdir -p -- "$XDG_CONFIG_HOME" "$XDG_STATE_HOME" "$TMPD/bin"
 
 CONFIG_FILE="${XDG_CONFIG_HOME}/hypr/hyprsunset.conf"
 SCHEDULE_FILE="${XDG_STATE_HOME}/hyprsunset/schedule"
+export HYPRSUNSET_IDENTITY_FILE="$TMPD/hyprsunset-identity"
+export HYPRCTL_LOG="$TMPD/hyprctl.log"
+printf '%s\n' false >"$HYPRSUNSET_IDENTITY_FILE"
+: >"$HYPRCTL_LOG"
+
+cat >"$TMPD/bin/hyprctl" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${HYPRCTL_LOG:?}"
+case "$*" in
+  'hyprsunset identity get')
+    cat "${HYPRSUNSET_IDENTITY_FILE:?}"
+    ;;
+  'hyprsunset identity')
+    printf '%s\n' true >"${HYPRSUNSET_IDENTITY_FILE:?}"
+    ;;
+  hyprsunset\ temperature\ *)
+    printf '%s\n' false >"${HYPRSUNSET_IDENTITY_FILE:?}"
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+FAKE
+
+cat >"$TMPD/bin/date" <<'FAKE'
+#!/usr/bin/env bash
+if [[ "${1:-}" == '+%H:%M' ]]; then
+  printf '%s\n' '12:00'
+else
+  /usr/bin/date "$@"
+fi
+FAKE
+chmod 0755 "$TMPD/bin/hyprctl" "$TMPD/bin/date"
+export PATH="$TMPD/bin:$PATH"
 
 bash -n "$SCRIPT"
+
+# Hyprsunset's IPC query is authoritative. Awtarchy must use identity get rather
+# than inferring the current manual state from schedule time or saved fallback.
+status="$(bash "$SCRIPT" status)"
+grep -Fqx 'identity=false' <<<"$status" || fail 'status does not use Hyprsunset identity get for the live state'
+grep -Fxq 'hyprsunset identity get' "$HYPRCTL_LOG" || fail 'Hyprsunset identity get was not queried'
+if grep -Fxq -- '-j hyprsunset' "$HYPRCTL_LOG"; then
+  fail 'Night Light still uses the obsolete hyprctl -j hyprsunset state query'
+fi
 
 # Overnight schedules must persist exact 24-hour times, generate native
 # hyprsunset profiles, and identify that the end occurs on the next day.
@@ -40,6 +84,20 @@ contains "$CONFIG_FILE" 'time = 20:00' 'generated config is missing the enable t
 contains "$CONFIG_FILE" 'temperature = 4500' 'generated config is missing the scheduled temperature'
 contains "$CONFIG_FILE" 'time = 07:00' 'generated config is missing the disable time'
 contains "$CONFIG_FILE" 'identity = true' 'generated config does not restore identity at disable time'
+
+# The visible On/Off button is a manual override. With a schedule still enabled,
+# an actually-on Night Light must toggle off immediately without disabling the
+# saved schedule. The schedule can take control again at its next boundary.
+printf '%s\n' false >"$HYPRSUNSET_IDENTITY_FILE"
+: >"$HYPRCTL_LOG"
+bash "$SCRIPT" toggle >/dev/null
+[[ "$(<"$HYPRSUNSET_IDENTITY_FILE")" == true ]] \
+  || fail 'manual toggle did not turn Night Light off while its schedule remained enabled'
+grep -Fxq 'hyprsunset identity get' "$HYPRCTL_LOG" \
+  || fail 'manual toggle did not query the live Hyprsunset identity state'
+status="$(bash "$SCRIPT" status)"
+grep -Fqx 'schedule_enabled=1' <<<"$status" \
+  || fail 'manual Night Light toggle incorrectly disabled its schedule'
 
 status="$(bash "$SCRIPT" status)"
 grep -Fqx 'schedule_enabled=1' <<<"$status" || fail 'status does not report enabled schedule'
@@ -140,4 +198,4 @@ do
 done
 (( missing_history == 0 )) || fail 'managed history is missing current Night Light schedule stock hashes'
 
-printf '%s\n' 'PASS: Night Light supports safe daily enable/disable scheduling with a scheduled temperature.'
+printf '%s\n' 'PASS: Night Light supports safe daily scheduling and authoritative manual toggles.'


### PR DESCRIPTION
Fix two Quick Settings state bugs:

- Keep the Bluetooth flyout keyed to the authoritative BlueZ power probe instead of allowing stale Quickshell adapter state to overwrite it. Re-probe on flyout open and adapter state changes.
- Query current Hyprsunset state through `hyprctl hyprsunset identity get` so the Night Light On/Off button works as a manual override while a schedule remains enabled.
- Add regression coverage for both behaviors.

Draft while CI and managed-history validation are being completed.