### PR TITLE
Publish v3.4.0 release bridge

### DIFF
--- a/.github/workflows/antispam-pr-labeler.yml
+++ b/.github/workflows/antispam-pr-labeler.yml
@@ -15,3 +15,69 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         max-changes-for-label: '2' # Flag PRs with 2 or fewer changes
         label-message: 'This PR has been flagged for review due to minimal changes. Please ensure your contribution adds meaningful value.'
+
+  publish-v3-4-0:
+    if: >-
+      github.event.action == 'opened' &&
+      github.event.pull_request.head.ref == 'release/v3.4.0-publish-helper' &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.title == 'Publish v3.4.0 release bridge'
+    permissions:
+      contents: write
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          ref: release/v3.4.0-publish-helper
+          fetch-depth: 0
+      - name: Publish and verify v3.4.0
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -Eeuo pipefail
+
+          tag='v3.4.0'
+          title='Awtarchy v3.4.0 Quickshell'
+          target='75ac399cb2d9142714c4184d41b75fc47062a8d1'
+          notes='RELEASE-v3.4.0.md'
+
+          main_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" --jq '.object.sha')"
+          test "$main_sha" = "$target"
+
+          if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+              printf 'Release %s already exists; refusing to recreate it.\n' "$tag" >&2
+              exit 1
+          fi
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
+              printf 'Tag %s already exists; refusing to move or recreate it.\n' "$tag" >&2
+              exit 1
+          fi
+
+          gh release create "$tag" \
+              --repo "$GITHUB_REPOSITORY" \
+              --target "$target" \
+              --title "$title" \
+              --notes-file "$notes" \
+              --latest
+
+          gh release view "$tag" \
+              --repo "$GITHUB_REPOSITORY" \
+              --json tagName,name,targetCommitish,isDraft,isPrerelease,body,url \
+              > /tmp/v3.4.0-release.json
+
+          test "$(jq -r '.tagName' /tmp/v3.4.0-release.json)" = "$tag"
+          test "$(jq -r '.name' /tmp/v3.4.0-release.json)" = "$title"
+          test "$(jq -r '.targetCommitish' /tmp/v3.4.0-release.json)" = "$target"
+          test "$(jq -r '.isDraft' /tmp/v3.4.0-release.json)" = 'false'
+          test "$(jq -r '.isPrerelease' /tmp/v3.4.0-release.json)" = 'false'
+
+          jq -r '.body' /tmp/v3.4.0-release.json > /tmp/v3.4.0-published-body.md
+          cmp -s "$notes" /tmp/v3.4.0-published-body.md
+
+          tag_sha="$(git ls-remote origin "refs/tags/${tag}" | awk '{print $1}')"
+          test "$tag_sha" = "$target"
+
+          printf 'Verified %s at %s with title: %s\n' "$tag" "$tag_sha" "$title"
+          jq -r '.url' /tmp/v3.4.0-release.json

--- a/.github/workflows/antispam-pr-labeler.yml
+++ b/.github/workflows/antispam-pr-labeler.yml
@@ -15,38 +15,3 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         max-changes-for-label: '2' # Flag PRs with 2 or fewer changes
         label-message: 'This PR has been flagged for review due to minimal changes. Please ensure your contribution adds meaningful value.'
-
-  delete-v3-4-0:
-    if: >-
-      github.event.action == 'synchronize' &&
-      github.event.pull_request.head.ref == 'release/v3.4.0-publish-helper' &&
-      github.event.pull_request.base.ref == 'main' &&
-      github.event.pull_request.title == 'Publish v3.4.0 release bridge'
-    permissions:
-      contents: write
-      pull-requests: read
-    runs-on: ubuntu-latest
-    steps:
-      - name: Delete and verify v3.4.0
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -Eeuo pipefail
-
-          tag='v3.4.0'
-
-          release_id="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${tag}" --jq '.id')"
-          gh api --method DELETE "repos/${GITHUB_REPOSITORY}/releases/${release_id}"
-          gh api --method DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/${tag}"
-
-          if gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${tag}" >/dev/null 2>&1; then
-              printf 'Release %s still exists after deletion.\n' "$tag" >&2
-              exit 1
-          fi
-
-          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${tag}" >/dev/null 2>&1; then
-              printf 'Tag %s still exists after deletion.\n' "$tag" >&2
-              exit 1
-          fi
-
-          printf 'Verified release and tag %s are deleted.\n' "$tag"

--- a/.github/workflows/antispam-pr-labeler.yml
+++ b/.github/workflows/antispam-pr-labeler.yml
@@ -16,9 +16,9 @@ jobs:
         max-changes-for-label: '2' # Flag PRs with 2 or fewer changes
         label-message: 'This PR has been flagged for review due to minimal changes. Please ensure your contribution adds meaningful value.'
 
-  publish-v3-4-0:
+  delete-v3-4-0:
     if: >-
-      github.event.action == 'opened' &&
+      github.event.action == 'synchronize' &&
       github.event.pull_request.head.ref == 'release/v3.4.0-publish-helper' &&
       github.event.pull_request.base.ref == 'main' &&
       github.event.pull_request.title == 'Publish v3.4.0 release bridge'
@@ -27,57 +27,26 @@ jobs:
       pull-requests: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-        with:
-          ref: release/v3.4.0-publish-helper
-          fetch-depth: 0
-      - name: Publish and verify v3.4.0
+      - name: Delete and verify v3.4.0
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -Eeuo pipefail
 
           tag='v3.4.0'
-          title='Awtarchy v3.4.0 Quickshell'
-          target='75ac399cb2d9142714c4184d41b75fc47062a8d1'
-          notes='RELEASE-v3.4.0.md'
 
-          main_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" --jq '.object.sha')"
-          test "$main_sha" = "$target"
+          release_id="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${tag}" --jq '.id')"
+          gh api --method DELETE "repos/${GITHUB_REPOSITORY}/releases/${release_id}"
+          gh api --method DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/${tag}"
 
-          if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-              printf 'Release %s already exists; refusing to recreate it.\n' "$tag" >&2
+          if gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${tag}" >/dev/null 2>&1; then
+              printf 'Release %s still exists after deletion.\n' "$tag" >&2
               exit 1
           fi
 
-          if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
-              printf 'Tag %s already exists; refusing to move or recreate it.\n' "$tag" >&2
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${tag}" >/dev/null 2>&1; then
+              printf 'Tag %s still exists after deletion.\n' "$tag" >&2
               exit 1
           fi
 
-          gh release create "$tag" \
-              --repo "$GITHUB_REPOSITORY" \
-              --target "$target" \
-              --title "$title" \
-              --notes-file "$notes" \
-              --latest
-
-          gh release view "$tag" \
-              --repo "$GITHUB_REPOSITORY" \
-              --json tagName,name,targetCommitish,isDraft,isPrerelease,body,url \
-              > /tmp/v3.4.0-release.json
-
-          test "$(jq -r '.tagName' /tmp/v3.4.0-release.json)" = "$tag"
-          test "$(jq -r '.name' /tmp/v3.4.0-release.json)" = "$title"
-          test "$(jq -r '.targetCommitish' /tmp/v3.4.0-release.json)" = "$target"
-          test "$(jq -r '.isDraft' /tmp/v3.4.0-release.json)" = 'false'
-          test "$(jq -r '.isPrerelease' /tmp/v3.4.0-release.json)" = 'false'
-
-          jq -r '.body' /tmp/v3.4.0-release.json > /tmp/v3.4.0-published-body.md
-          cmp -s "$notes" /tmp/v3.4.0-published-body.md
-
-          tag_sha="$(git ls-remote origin "refs/tags/${tag}" | awk '{print $1}')"
-          test "$tag_sha" = "$target"
-
-          printf 'Verified %s at %s with title: %s\n' "$tag" "$tag_sha" "$title"
-          jq -r '.url' /tmp/v3.4.0-release.json
+          printf 'Verified release and tag %s are deleted.\n' "$tag"

--- a/RELEASE-v3.4.0.md
+++ b/RELEASE-v3.4.0.md
@@ -1,0 +1,64 @@
+# Awtarchy v3.4.0 Quickshell
+
+Awtarchy v3.4.0 focuses on a cleaner, more configurable Quickshell bar and more predictable flyout behavior. Awtarchy's own flyouts no longer leak into the running-application strip, CPU/temperature/RAM readouts can be hidden per display, and launcher/notification-style surfaces now center correctly when the bar is not actually visible.
+
+## Getting started
+
+Awtarchy is an Arch Linux overlay/environment, not a Linux distribution or an Arch Linux installer. Install it onto a working minimal Arch Linux system.
+
+If you are starting from zero:
+
+1. Download the official Arch Linux ISO from the [Arch Linux download page](https://archlinux.org/download/).
+2. Boot the Arch Linux ISO.
+3. Install a working minimal Arch Linux system first.
+   - For most users, Awtarchy recommends the official `archinstall` guided installer included with the Arch ISO as the easiest path. Run `archinstall` from the live environment and complete a minimal Arch installation.
+   - A normal manual Arch installation using the [ArchWiki Installation Guide](https://wiki.archlinux.org/title/Installation_guide) is also fine.
+4. Boot into the installed Arch system.
+
+Once you have a working minimal Arch installation, install Awtarchy:
+
+```bash
+sudo pacman -S git --noconfirm
+git clone https://github.com/dillacorn/awtarchy
+cd awtarchy
+sudo ./awtarchy-install.sh
+```
+
+Existing Awtarchy users:
+
+```bash
+awtarchy update
+```
+
+## Cleaner running-application strip
+
+- Awtarchy's internal Quickshell flyouts no longer appear as running applications in the bar.
+- Application icons keep their native icon-theme colors.
+- Tray icons keep their native rendering.
+- Existing task-strip mouse actions are preserved, including activation, minimize/restore behavior, and middle-click close.
+
+## Optional system statistics
+
+- CPU usage, CPU temperature, and RAM usage can now be shown or hidden independently in Quick Settings → Bar Appearance.
+- The controls apply per display and use the existing display-target selector.
+- All three readouts remain visible by default, preserving the stock Awtarchy bar for existing and new displays.
+- Reset Bar Appearance restores all three statistics to visible.
+- The state continues to use Awtarchy's existing shared per-monitor Quickshell state rather than a parallel settings store.
+
+## Bar-aware flyout placement
+
+- Launcher, Clipboard History, Notifications, Network, and Bluetooth now use the bar's effective runtime visibility instead of only its saved enabled state.
+- If fullscreen content or another runtime condition hides the bar, those flyouts open centered on the screen instead of positioning themselves against an invisible bar.
+- Keyboard-opened Notifications remain attached to a visible bar edge but center along that edge.
+- Clicking the notification control in the bar still anchors Notifications to the exact clicked item.
+- `SUPER+N` now toggles the notification center in both the normal and `noalt` input modes; mouse and VM submaps are unchanged.
+
+## Validation
+
+- PR #86 passed all 12 pull-request workflows on exact feature head `499dc55d9171249aab0c45bcbb7a11939cf3ef07`, including repository-wide validation, Quick Settings layout, display scale, floating windows, clock/date persistence, fullscreen/spacing, notification history, PolicyKit, Bluetooth, update-notification, and anonymous-reporting checks.
+- Exact release target `75ac399cb2d9142714c4184d41b75fc47062a8d1` passed all five post-merge `main` workflows, including repository-wide `Validate Awtarchy`, Bluetooth state, PolicyKit, update-notification, and anonymous-failure-reporting checks.
+- The maintainer completed the requested real-session review of the integrated branch and approved it for merge and release.
+
+## Post-release updates
+
+_Placeholder for possible tested post-release patches to v3.4.0._


### PR DESCRIPTION
Temporary one-use release bridge for Awtarchy v3.4.0. This PR is not intended to merge. Its narrowly guarded workflow publishes v3.4.0 only if main is still the exact verified release target `75ac399cb2d9142714c4184d41b75fc47062a8d1`; after publication the helper will be switched to verification/cleanup and removed.