### PR TITLE
Make failure reports user-facing through awtarchy

### DIFF
--- a/config/hypr/scripts/awtarchy_report_failure.sh
+++ b/config/hypr/scripts/awtarchy_report_failure.sh
@@ -462,10 +462,14 @@ prompt_report() {
 }
 
 notify_pending() {
-    local count=0 path="" current_state="" previous_state="" tmp="" body=""
+    local count=0 path="" current_state="" previous_state="" tmp="" body="" notify_lock_fd=""
     local -a pending=()
 
     [[ -d "$REPORT_DIR" && ! -L "$REPORT_DIR" && -O "$REPORT_DIR" ]] || return 0
+    command -v flock >/dev/null 2>&1 || return 0
+    exec {notify_lock_fd}<"$REPORT_DIR" || return 0
+    flock -x "$notify_lock_fd" || return 0
+
     shopt -s nullglob
     local reports=("$REPORT_DIR"/*.json)
     shopt -u nullglob

--- a/config/hypr/scripts/awtarchy_report_failure.sh
+++ b/config/hypr/scripts/awtarchy_report_failure.sh
@@ -502,7 +502,12 @@ notify_pending() {
 
 pending_reports() {
     local quiet_empty="${1:-0}"
-    [[ -d "$REPORT_DIR" && ! -L "$REPORT_DIR" && -O "$REPORT_DIR" ]] || return 0
+    if [[ ! -d "$REPORT_DIR" || -L "$REPORT_DIR" || ! -O "$REPORT_DIR" ]]; then
+        if (( quiet_empty == 0 )); then
+            printf 'No pending Awtarchy failure reports.\n'
+        fi
+        return 0
+    fi
     shopt -s nullglob
     local reports=("$REPORT_DIR"/*.json)
     shopt -u nullglob

--- a/config/hypr/scripts/awtarchy_report_failure.sh
+++ b/config/hypr/scripts/awtarchy_report_failure.sh
@@ -9,6 +9,7 @@ STATE_HOME="${XDG_STATE_HOME:-${HOME}/.local/state}"
 CACHE_HOME="${XDG_CACHE_HOME:-${HOME}/.cache}"
 CONFIG_HOME="${XDG_CONFIG_HOME:-${HOME}/.config}"
 REPORT_DIR="${STATE_HOME}/awtarchy/reports"
+NOTIFY_STATE_FILE="${REPORT_DIR}/.notification-state"
 COMMAND_VERSION_FILE="${STATE_HOME}/awtarchy/command-version"
 CONFIG_VERSION_FILE="${STATE_HOME}/awtarchy/config-version"
 QUICKSHELL_LOG="${CACHE_HOME}/awtarchy/quickshell.log"
@@ -193,6 +194,14 @@ managed_report_path() {
     report_basename_allowed "$base" || return 2
     [[ "$path" == "$REPORT_DIR/$base" ]] || return 2
     [[ -f "$path" && ! -L "$path" && -O "$path" ]] || return 2
+}
+
+clear_notification_state() {
+    if [[ ! -e "$NOTIFY_STATE_FILE" && ! -L "$NOTIFY_STATE_FILE" ]]; then
+        return 0
+    fi
+    [[ -f "$NOTIFY_STATE_FILE" && ! -L "$NOTIFY_STATE_FILE" && -O "$NOTIFY_STATE_FILE" ]] || return 0
+    rm -f -- "$NOTIFY_STATE_FILE"
 }
 
 validate_pending_payload() {
@@ -383,6 +392,7 @@ submit_report() {
 
     issue_url="$(jq -r '.issue_url' <<<"$response" 2>/dev/null || true)"
     rm -f -- "$path"
+    clear_notification_state
     printf 'Awtarchy failure report sent: %s\n' "$issue_url"
 }
 
@@ -403,6 +413,7 @@ discard_report() {
     fi
     managed_report_path "$path" || return 2
     rm -f -- "$path"
+    clear_notification_state
 }
 
 interactive_terminal() {
@@ -451,21 +462,42 @@ prompt_report() {
 }
 
 notify_pending() {
-    local count=0 path=""
+    local count=0 path="" current_state="" previous_state="" tmp="" body=""
+    local -a pending=()
+
     [[ -d "$REPORT_DIR" && ! -L "$REPORT_DIR" && -O "$REPORT_DIR" ]] || return 0
     shopt -s nullglob
     local reports=("$REPORT_DIR"/*.json)
     shopt -u nullglob
     for path in "${reports[@]}"; do
         managed_report_path "$path" || continue
-        ((count += 1))
+        pending+=("${path##*/}")
     done
-    (( count > 0 )) || return 0
+    count="${#pending[@]}"
+    if (( count == 0 )); then
+        clear_notification_state
+        return 0
+    fi
+
+    current_state="$(printf '%s\n' "${pending[@]}" | LC_ALL=C sort)"
+    if [[ -f "$NOTIFY_STATE_FILE" && ! -L "$NOTIFY_STATE_FILE" && -O "$NOTIFY_STATE_FILE" ]]; then
+        previous_state="$(cat -- "$NOTIFY_STATE_FILE" 2>/dev/null || true)"
+        [[ "$previous_state" == "$current_state" ]] && return 0
+    fi
+
     command -v notify-send >/dev/null 2>&1 || return 0
-    notify-send \
-        'Awtarchy failure report pending' \
-        "${count} sanitized failure report(s) are waiting. Run ~/.config/hypr/scripts/awtarchy_report_failure.sh pending to review." \
-        >/dev/null 2>&1 || true
+    if (( count == 1 )); then
+        body=$'A sanitized failure report is ready to review.\nRun: awtarchy report\nYou can review it before choosing whether to send it.'
+    else
+        body="${count} sanitized failure reports are ready to review."$'\nRun: awtarchy report\nYou can review each report before choosing whether to send it.'
+    fi
+
+    if notify-send 'Awtarchy detected a problem' "$body" >/dev/null 2>&1; then
+        tmp="${NOTIFY_STATE_FILE}.tmp.$$"
+        printf '%s\n' "$current_state" >"$tmp" || { rm -f -- "$tmp"; return 0; }
+        chmod 0600 -- "$tmp" || { rm -f -- "$tmp"; return 0; }
+        mv -f -- "$tmp" "$NOTIFY_STATE_FILE" || rm -f -- "$tmp"
+    fi
 }
 
 pending_reports() {

--- a/docs/anonymous-failure-reporting.md
+++ b/docs/anonymous-failure-reporting.md
@@ -19,7 +19,7 @@ known Awtarchy failure
   -> Awtarchy Report Bot GitHub issue
 ```
 
-Noninteractive failure paths queue the report but never invent consent or spawn a terminal. The report remains local until a user explicitly submits or discards it. Once Quickshell becomes healthy again, Awtarchy may notify the user that sanitized reports are waiting. If Quickshell remains unavailable, opening the interactive `awtarchy` maintenance menu also surfaces any valid pending reports.
+Noninteractive failure paths queue the report but never invent consent or spawn a terminal. The report remains local until a user explicitly submits or discards it. Once Quickshell becomes healthy again, Awtarchy may notify the user that sanitized reports are waiting and directs the user to run `awtarchy report`. That command opens the existing Send / Review / Don't send flow, so the report can be inspected before any submission. Repeated startup paths are serialized and an unchanged pending-report state is notified only once. If Quickshell remains unavailable, opening the interactive `awtarchy` maintenance menu also surfaces any valid pending reports.
 
 ## Security invariants
 

--- a/local/bin/awtarchy
+++ b/local/bin/awtarchy
@@ -735,6 +735,13 @@ exec_runtime() {
   exec bash "$RUNTIME" "$@"
 }
 
+run_failure_reports() {
+  local report_helper="${TARGET_HOME}/.config/hypr/scripts/awtarchy_report_failure.sh"
+  [[ -f "$report_helper" && ! -L "$report_helper" && -O "$report_helper" ]] \
+    || die "Awtarchy failure reporting is unavailable. Run 'awtarchy update' to restore the managed reporting helper."
+  bash "$report_helper" pending
+}
+
 replace_quickshell_ui_from_baseline() {
   local rel="$1" baseline_root="$2" stamp="$3"
   local baseline="${baseline_root}/${rel}"
@@ -1105,6 +1112,7 @@ Usage:
   awtarchy update [--tag <tag>] [update options]
   awtarchy reset [--tag <tag>] [update options]
   awtarchy review [--tag <tag>]
+  awtarchy report
   awtarchy git
   awtarchy git review --branch <branch> [--commit <40-character-sha>]
   awtarchy git update --branch <branch> [--commit <40-character-sha>] [update options]
@@ -1139,6 +1147,12 @@ main() {
       (( $# == 0 )) || die "troubleshoot does not accept options."
       require_runtime
       AWTARCHY_TROUBLESHOOT_COMMAND=awtarchy exec bash "$RUNTIME" troubleshoot
+      ;;
+    report)
+      shift
+      (( $# == 0 )) || die "report does not accept options."
+      run_failure_reports
+      return 0
       ;;
     version)
       print_version_status

--- a/tests/test-anonymous-reporting.sh
+++ b/tests/test-anonymous-reporting.sh
@@ -46,6 +46,7 @@ printf '{"ok":true,"created":true,"deduplicated":false,"issue_number":99,"issue_
 SH
 cat >"$BIN/notify-send" <<'SH'
 #!/usr/bin/env bash
+sleep "${NOTIFY_DELAY:-0}"
 printf '%s\n' "$*" >>"$NOTIFY_CALLS"
 SH
 chmod +x "$BIN"/*
@@ -109,6 +110,26 @@ if grep -Fq 'awtarchy_report_failure.sh' "$NOTIFY_CALLS"; then
     echo 'pending-report notification exposes the internal reporting script' >&2
     exit 1
 fi
+
+bash "$SCRIPT" capture quickshell start quickshell_not_ready
+SECOND_REPORT="$STATE/awtarchy/reports/quickshell--start--quickshell_not_ready.json"
+[[ -f "$SECOND_REPORT" ]]
+before_notify_count="$(wc -l <"$NOTIFY_CALLS")"
+export NOTIFY_DELAY=0.2
+bash "$SCRIPT" notify-pending &
+notify_pid_one=$!
+bash "$SCRIPT" notify-pending &
+notify_pid_two=$!
+wait "$notify_pid_one"
+wait "$notify_pid_two"
+unset NOTIFY_DELAY
+after_notify_count="$(wc -l <"$NOTIFY_CALLS")"
+[[ $((after_notify_count - before_notify_count)) == 1 ]] || {
+    echo 'concurrent pending-report checks produced duplicate notifications' >&2
+    exit 1
+}
+bash "$SCRIPT" discard "$SECOND_REPORT"
+[[ ! -e "$SECOND_REPORT" ]]
 
 jq -e --arg attempted "$ATTEMPTED_VERSION" '
   keys == [

--- a/tests/test-anonymous-reporting.sh
+++ b/tests/test-anonymous-reporting.sh
@@ -47,7 +47,8 @@ SH
 cat >"$BIN/notify-send" <<'SH'
 #!/usr/bin/env bash
 sleep "${NOTIFY_DELAY:-0}"
-printf '%s\n' "$*" >>"$NOTIFY_CALLS"
+printf '%q ' "$@" >>"$NOTIFY_CALLS"
+printf '\n' >>"$NOTIFY_CALLS"
 SH
 chmod +x "$BIN"/*
 

--- a/tests/test-anonymous-reporting.sh
+++ b/tests/test-anonymous-reporting.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCRIPT="${ROOT}/config/hypr/scripts/awtarchy_report_failure.sh"
+LAUNCHER="${ROOT}/local/bin/awtarchy"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 HOME_DIR="$TMP/home"
@@ -43,12 +44,17 @@ if [[ ${CURL_PENDING:-0} == 1 ]]; then
 fi
 printf '{"ok":true,"created":true,"deduplicated":false,"issue_number":99,"issue_url":"https://github.com/dillacorn/awtarchy/issues/99"}\n'
 SH
+cat >"$BIN/notify-send" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$NOTIFY_CALLS"
+SH
 chmod +x "$BIN"/*
 
 export HOME="$HOME_DIR"
 export XDG_STATE_HOME="$STATE"
 export PATH="$BIN:/usr/bin:/bin"
 export CURL_CALLS="$TMP/curl.calls"
+export NOTIFY_CALLS="$TMP/notify.calls"
 export AWTARCHY_REPORT_NO_PROMPT=1
 
 grep -Fq 'public GitHub issue' "$SCRIPT" || {
@@ -65,6 +71,21 @@ fi
     exit 1
 }
 
+mkdir -p "$HOME_DIR/.config/hypr/scripts"
+cp -- "$SCRIPT" "$HOME_DIR/.config/hypr/scripts/awtarchy_report_failure.sh"
+chmod 0755 "$HOME_DIR/.config/hypr/scripts/awtarchy_report_failure.sh"
+report_command_output="$(
+    HOME="$HOME_DIR" \
+    XDG_CONFIG_HOME="$HOME_DIR/.config" \
+    XDG_STATE_HOME="$STATE" \
+    AWTARCHY_SKIP_UPDATE_CHECK=1 \
+    "$LAUNCHER" report
+)"
+grep -Fq 'No pending Awtarchy failure reports.' <<<"$report_command_output" || {
+    echo 'awtarchy report did not open the pending-report flow' >&2
+    exit 1
+}
+
 ATTEMPTED_VERSION='anonymous-crash-reporting-testing@fedcba9876543210fedcba9876543210fedcba98'
 export AWTARCHY_REPORT_CONFIG_VERSION_OVERRIDE="$ATTEMPTED_VERSION"
 bash "$SCRIPT" capture quickshell restart_after_update quickshell_not_ready
@@ -73,6 +94,21 @@ REPORT="$STATE/awtarchy/reports/quickshell--restart_after_update--quickshell_not
 [[ -f "$REPORT" ]]
 [[ "$(stat -c '%a' "$REPORT")" == 600 ]]
 [[ ! -e "$CURL_CALLS" ]]
+
+bash "$SCRIPT" notify-pending
+bash "$SCRIPT" notify-pending
+[[ "$(wc -l <"$NOTIFY_CALLS")" == 1 ]] || {
+    echo 'the same pending-report state produced duplicate notifications' >&2
+    exit 1
+}
+grep -Fq 'awtarchy report' "$NOTIFY_CALLS" || {
+    echo 'pending-report notification does not direct the user to awtarchy report' >&2
+    exit 1
+}
+if grep -Fq 'awtarchy_report_failure.sh' "$NOTIFY_CALLS"; then
+    echo 'pending-report notification exposes the internal reporting script' >&2
+    exit 1
+fi
 
 jq -e --arg attempted "$ATTEMPTED_VERSION" '
   keys == [


### PR DESCRIPTION
## Summary

- add a first-class `awtarchy report` command for pending sanitized failure reports
- change the desktop notification to tell users exactly to run `awtarchy report` instead of exposing the internal helper script
- preserve the existing Review / Send / Don't send consent flow
- suppress duplicate notifications for the same pending-report state, including concurrent Quickshell startup paths
- document the user-facing reporting flow

## Validation

- TDD red: the first regression run failed because `awtarchy report` did not exist
- TDD red: the concurrency regression failed with `concurrent pending-report checks produced duplicate notifications`
- `Validate Anonymous Failure Reporting` passed on head `0e5d2900330ed4e583ea17d81263b5034546493b`
- `Validate Awtarchy` passed on the same head, including Bash syntax, ShellCheck, and command/updater integration tests
- PolicyKit and Theme Picker composition workflows also passed on the same head

Issue #90 remains a separate resume-recovery failure investigation; this PR improves how users review and submit reports rather than claiming to fix that underlying failure.