### PR TITLE
Fix package reconciler alternatives

### DIFF
--- a/.github/workflows/package-reconciler-red-green.yml
+++ b/.github/workflows/package-reconciler-red-green.yml
@@ -23,10 +23,14 @@ jobs:
           bash -n local/bin/awtarchy
           bash -n local/share/awtarchy/awtarchy-package-reconcile.sh
           bash -n tests/test-package-reconciler.sh
+          bash -n tests/test-package-reconciler-alternatives.sh
       - name: ShellCheck
         run: |
           shellcheck local/bin/awtarchy
           shellcheck local/share/awtarchy/awtarchy-package-reconcile.sh
           shellcheck tests/test-package-reconciler.sh
+          shellcheck tests/test-package-reconciler-alternatives.sh
       - name: Package reconciler regression
-        run: bash tests/test-package-reconciler.sh
+        run: |
+          bash tests/test-package-reconciler.sh
+          bash tests/test-package-reconciler-alternatives.sh

--- a/local/share/awtarchy/awtarchy-package-reconcile.sh
+++ b/local/share/awtarchy/awtarchy-package-reconcile.sh
@@ -179,6 +179,23 @@ package_installed() {
   pacman -Q "$1" >/dev/null 2>&1
 }
 
+package_satisfied() {
+  local pkg="$1"
+  package_installed "$pkg" && return 0
+
+  case "$pkg" in
+    zathura-pdf-mupdf)
+      package_installed zathura-pdf-poppler
+      ;;
+    zathura-pdf-poppler)
+      package_installed zathura-pdf-mupdf
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
 managed_package() {
   [[ -r "$MANAGED_PACKAGES_FILE" ]] || return 1
   grep -Fxq -- "$1" "$MANAGED_PACKAGES_FILE"
@@ -244,7 +261,7 @@ collect_state() {
   done
 
   for pkg in "${ARCH_CATALOG[@]}"; do
-    package_installed "$pkg" && continue
+    package_satisfied "$pkg" && continue
     array_contains "$pkg" "${REQUIRED_ARCH[@]}" && continue
     [[ $pkg == ly ]] && continue
     MISSING_ARCH+=("$pkg")

--- a/tests/test-package-reconciler-alternatives.sh
+++ b/tests/test-package-reconciler-alternatives.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+RECONCILER="${ROOT}/local/share/awtarchy/awtarchy-package-reconcile.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf -- "$TMP"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+home="${TMP}/home"
+fakebin="${TMP}/fakebin"
+runtime="${TMP}/awtarchy-runtime.sh"
+mkdir -p "$home/.local/state/awtarchy" "$fakebin"
+printf '%s\n' 'is_laptop=false' >"$home/.local/state/awtarchy/hardware-state"
+
+cat >"$runtime" <<'EOF_RUNTIME'
+declare -a PKG_GROUPS=(
+  "Window Management:quickshell wl-clipboard cliphist"
+  "Utilities:upower polkit python-gobject jq zathura-pdf-mupdf optional-window-tool"
+)
+declare -a PACKAGES_AUR=()
+declare -a FLATPAK_CATALOG=()
+EOF_RUNTIME
+
+cat >"$fakebin/pacman" <<'EOF_PACMAN'
+#!/usr/bin/env bash
+set -euo pipefail
+installed=(
+  quickshell
+  wl-clipboard
+  cliphist
+  upower
+  playerctl
+  hyprland-qt-support
+  polkit
+  python-gobject
+  jq
+  zathura-pdf-poppler
+)
+case "${1:-}" in
+  -Q)
+    needle="${2:-}"
+    for pkg in "${installed[@]}"; do
+      [[ $pkg == "$needle" ]] && exit 0
+    done
+    exit 1
+    ;;
+  *)
+    printf 'unexpected pacman invocation: %q' "$@" >&2
+    printf '\n' >&2
+    exit 90
+    ;;
+esac
+EOF_PACMAN
+chmod +x "$fakebin/pacman"
+
+cat >"$fakebin/systemctl" <<'EOF_SYSTEMCTL'
+#!/usr/bin/env bash
+exit 1
+EOF_SYSTEMCTL
+chmod +x "$fakebin/systemctl"
+
+output="$({
+  PATH="$fakebin:/usr/bin:/bin" \
+  HOME="$home" \
+  USER=tester \
+  AWTARCHY_RUNTIME="$runtime" \
+  AWTARCHY_MANAGED_PACKAGES_FILE="${TMP}/managed-packages" \
+  "$RECONCILER" --review
+} 2>&1)"
+
+printf '%s\n' "$output" | grep -Fq 'optional-window-tool' \
+  || fail "review did not load ordinary missing catalog packages"
+if printf '%s\n' "$output" | grep -Fq 'zathura-pdf-mupdf'; then
+  fail "installed zathura-pdf-poppler did not satisfy the Zathura PDF backend family"
+fi
+
+printf 'PASS: installed package alternatives satisfy reconciliation families\n'


### PR DESCRIPTION
Fixes the package reconciler incorrectly offering mutually exclusive alternatives as missing. Reproduced with zathura-pdf-poppler installed while zathura-pdf-mupdf is in the current Awtarchy catalog. Test-first: the new regression test should fail until the reconciler treats an installed alternative as satisfying that package family.