### PR TITLE
Recover package reconciliation after pacman upgrades

### DIFF
--- a/.github/workflows/package-reconciler-red-green.yml
+++ b/.github/workflows/package-reconciler-red-green.yml
@@ -24,13 +24,16 @@ jobs:
           bash -n local/share/awtarchy/awtarchy-package-reconcile.sh
           bash -n tests/test-package-reconciler.sh
           bash -n tests/test-package-reconciler-alternatives.sh
+          bash -n tests/test-package-reconciler-interrupted-recovery.sh
       - name: ShellCheck
         run: |
           shellcheck local/bin/awtarchy
           shellcheck local/share/awtarchy/awtarchy-package-reconcile.sh
           shellcheck tests/test-package-reconciler.sh
           shellcheck tests/test-package-reconciler-alternatives.sh
+          shellcheck tests/test-package-reconciler-interrupted-recovery.sh
       - name: Package reconciler regression
         run: |
           bash tests/test-package-reconciler.sh
           bash tests/test-package-reconciler-alternatives.sh
+          bash tests/test-package-reconciler-interrupted-recovery.sh

--- a/local/share/awtarchy/awtarchy-package-reconcile.sh
+++ b/local/share/awtarchy/awtarchy-package-reconcile.sh
@@ -53,6 +53,7 @@ declare -a RETIRED_MANAGED=()
 declare -a RETIRED_UNOWNED=()
 SYSTEM_TYPE="unknown"
 LY_STATUS="not installed"
+AUR_HELPER=""
 
 log()  { printf '%s\n' "$*"; }
 warn() { printf 'WARN: %s\n' "$*" >&2; }
@@ -414,6 +415,31 @@ confirm_yes_no() {
   esac
 }
 
+choose_ly_action() {
+  install_ly=0
+  enable_ly=0
+
+  case "$LY_STATUS" in
+    'not installed')
+      if confirm_yes_no 'Install and enable Ly on tty2?' 0; then
+        install_ly=1
+        enable_ly=1
+      fi
+      ;;
+    'installed, not enabled on tty2')
+      if confirm_yes_no 'Enable installed Ly on tty2?' 0; then
+        enable_ly=1
+      fi
+      ;;
+    'installed and enabled on tty2')
+      printf '\nLy is already installed and enabled on tty2; leaving it unchanged.\n' >/dev/tty
+      ;;
+    *)
+      printf '\nLy state is %s; leaving it unchanged.\n' "$LY_STATUS" >/dev/tty
+      ;;
+  esac
+}
+
 selected_values() {
   local values_name="$1" flags_name="$2" output_name="$3"
   local -n values="$values_name"
@@ -440,6 +466,82 @@ as_root() {
   else
     sudo -- "$@"
   fi
+}
+
+aur_helper_usable() {
+  local helper="$1"
+  have "$helper" || return 1
+  "$helper" --version >/dev/null 2>&1
+}
+
+rebuild_aur_helper() {
+  local helper="$1" tmp pkg
+
+  case "$helper" in
+    paru|yay) ;;
+    *) die "Unsupported AUR helper rebuild target: ${helper}" ;;
+  esac
+
+  package_installed "$helper" \
+    || die "${helper} exists but is not installed as the standard ${helper} package; refusing to replace an unknown helper variant."
+  have git || die "git is required to rebuild the broken ${helper} AUR helper."
+  have makepkg || die "makepkg is required to rebuild the broken ${helper} AUR helper."
+  (( EUID != 0 )) \
+    || die "AUR helper rebuild must run from the regular user account, not as root."
+
+  tmp="$(mktemp -d)"
+  log "Rebuilding broken AUR helper ${helper} against the current pacman/libalpm..."
+
+  if ! git clone --depth 1 "https://aur.archlinux.org/${helper}.git" "${tmp}/${helper}"; then
+    rm -rf -- "$tmp"
+    die "Failed to download ${helper} AUR source for rebuild."
+  fi
+
+  if ! (
+    cd -- "${tmp}/${helper}"
+    makepkg -s --noconfirm
+  ); then
+    rm -rf -- "$tmp"
+    die "Failed to rebuild ${helper} against the current pacman/libalpm."
+  fi
+
+  pkg="$(find "${tmp}/${helper}" -maxdepth 1 -type f -name "${helper}-*.pkg.tar*" ! -name '*-debug*' -print -quit)"
+  if [[ -z $pkg ]]; then
+    rm -rf -- "$tmp"
+    die "Rebuilt ${helper} package archive was not found."
+  fi
+
+  if ! as_root pacman -U --noconfirm "$pkg"; then
+    rm -rf -- "$tmp"
+    die "Failed to reinstall rebuilt ${helper}."
+  fi
+
+  rm -rf -- "$tmp"
+  aur_helper_usable "$helper" \
+    || die "${helper} is still unusable after rebuild."
+}
+
+ensure_aur_helper() {
+  local helper
+  AUR_HELPER=""
+
+  for helper in paru yay; do
+    if aur_helper_usable "$helper"; then
+      AUR_HELPER="$helper"
+      return 0
+    fi
+  done
+
+  for helper in paru yay; do
+    if have "$helper" && package_installed "$helper"; then
+      warn "${helper} is installed but cannot run after system package changes; rebuilding it."
+      rebuild_aur_helper "$helper"
+      AUR_HELPER="$helper"
+      return 0
+    fi
+  done
+
+  die "AUR packages were selected but no usable standard paru or yay installation is available."
 }
 
 record_managed_packages() {
@@ -555,11 +657,8 @@ if (( ${#flatpak_labels[@]} )); then
 fi
 
 install_ly=0
-if [[ $LY_STATUS == 'not installed' ]]; then
-  if confirm_yes_no 'Install and enable Ly on tty2?' 0; then install_ly=1; fi
-else
-  printf '\nLy is already %s; this reconciler will leave it installed.\n' "$LY_STATUS" >/dev/tty
-fi
+enable_ly=0
+choose_ly_action
 
 # Retired packages: Awtarchy-owned defaults selected; unowned defaults kept.
 declare -a retired_labels=()
@@ -598,10 +697,10 @@ printf '\n' >/dev/tty
 print_list 'Install Flatpak apps:' "${selected_flatpak[@]}" >/dev/tty
 printf '\n' >/dev/tty
 print_list 'Remove retired/replaced packages:' "${selected_retired[@]}" >/dev/tty
-if (( install_ly == 1 )); then printf '\nLy: enable ly@tty2.service and disable getty@tty2.service\n' >/dev/tty; fi
+if (( enable_ly == 1 )); then printf '\nLy: enable ly@tty2.service and disable getty@tty2.service\n' >/dev/tty; fi
 printf '\nNo current installed package will be removed merely because it was not selected.\n\n' >/dev/tty
 
-if (( ${#install_arch[@]} == 0 && ${#selected_aur[@]} == 0 && ${#selected_flatpak[@]} == 0 && ${#selected_retired[@]} == 0 && install_ly == 0 )); then
+if (( ${#install_arch[@]} == 0 && ${#selected_aur[@]} == 0 && ${#selected_flatpak[@]} == 0 && ${#selected_retired[@]} == 0 && enable_ly == 0 )); then
   log 'No package changes selected.'
   exit 0
 fi
@@ -615,12 +714,17 @@ if (( ${#install_arch[@]} )); then
   record_managed_packages "${install_arch[@]}"
 fi
 
+if (( enable_ly == 1 )); then
+  have systemctl || die "Ly is installed but systemctl is unavailable for tty2 setup."
+  as_root systemctl disable getty@tty2.service >/dev/null 2>&1 || true
+  as_root systemctl enable ly@tty2.service
+  log 'Ly enabled on tty2; getty@tty2 disabled.'
+fi
+
 if (( ${#selected_aur[@]} )); then
-  aur_helper=""
-  if have paru; then aur_helper=paru; elif have yay; then aur_helper=yay; fi
-  [[ -n $aur_helper ]] || die "AUR packages were selected but neither paru nor yay is installed."
-  log "Installing AUR packages with ${aur_helper}: ${selected_aur[*]}"
-  "$aur_helper" -S --needed --noconfirm "${selected_aur[@]}"
+  ensure_aur_helper
+  log "Installing AUR packages with ${AUR_HELPER}: ${selected_aur[*]}"
+  "$AUR_HELPER" -S --needed --noconfirm "${selected_aur[@]}"
   record_managed_packages "${selected_aur[@]}"
 fi
 
@@ -629,13 +733,6 @@ if (( ${#selected_flatpak[@]} )); then
   scope="$(flatpak_scope)"
   log "Installing Flatpak apps in ${scope} scope: ${selected_flatpak[*]}"
   install_flatpak_apps "$scope" "${selected_flatpak[@]}"
-fi
-
-if (( install_ly == 1 )); then
-  have systemctl || die "Ly was installed but systemctl is unavailable for tty2 setup."
-  as_root systemctl disable getty@tty2.service >/dev/null 2>&1 || true
-  as_root systemctl enable ly@tty2.service
-  log 'Ly enabled on tty2; getty@tty2 disabled.'
 fi
 
 if (( ${#selected_retired[@]} )); then

--- a/tests/test-package-reconciler-interrupted-recovery.sh
+++ b/tests/test-package-reconciler-interrupted-recovery.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+RECONCILER="${ROOT}/local/share/awtarchy/awtarchy-package-reconcile.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf -- "$TMP"' EXIT
+
+failures=0
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  failures=$((failures + 1))
+}
+
+home="${TMP}/home"
+fakebin="${TMP}/fakebin"
+runtime="${TMP}/awtarchy-runtime.sh"
+logfile="${TMP}/commands.log"
+mkdir -p "$home/.local/share/awtarchy" "$home/.local/state/awtarchy" "$fakebin"
+printf '%s\n' 'is_laptop=true' >"$home/.local/state/awtarchy/hardware-state"
+
+cat >"$runtime" <<'EOF_RUNTIME'
+declare -a PKG_GROUPS=(
+  "Window Management:quickshell wl-clipboard cliphist"
+  "Utilities:upower polkit python-gobject jq"
+)
+declare -a PACKAGES_AUR=(smtty)
+declare -a FLATPAK_CATALOG=()
+EOF_RUNTIME
+
+cat >"$fakebin/pacman" <<'EOF_PACMAN'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'pacman' >>"$TEST_LOG"
+printf ' %q' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+case "${1:-}" in
+  -Q)
+    case "${2:-}" in
+      ly|yay) exit 0 ;;
+      *) exit 1 ;;
+    esac
+    ;;
+  -U)
+    cat >"$TEST_FAKEBIN/yay" <<'EOF_YAY_FIXED'
+#!/usr/bin/env bash
+if [[ ${1:-} == --version ]]; then
+  printf '%s\n' 'yay v99-rebuilt'
+  exit 0
+fi
+exit 0
+EOF_YAY_FIXED
+    chmod +x "$TEST_FAKEBIN/yay"
+    exit 0
+    ;;
+  *) exit 0 ;;
+esac
+EOF_PACMAN
+chmod +x "$fakebin/pacman"
+
+cat >"$fakebin/yay" <<'EOF_YAY_BROKEN'
+#!/usr/bin/env bash
+printf '%s\n' 'yay: error while loading shared libraries: libalpm.so.15: cannot open shared object file: No such file or directory' >&2
+exit 127
+EOF_YAY_BROKEN
+chmod +x "$fakebin/yay"
+
+cat >"$fakebin/git" <<'EOF_GIT'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'git' >>"$TEST_LOG"
+printf ' %q' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+[[ ${1:-} == clone ]] || exit 90
+dest="${@: -1}"
+mkdir -p "$dest"
+printf '%s\n' '# test PKGBUILD placeholder' >"$dest/PKGBUILD"
+EOF_GIT
+chmod +x "$fakebin/git"
+
+cat >"$fakebin/makepkg" <<'EOF_MAKEPKG'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'makepkg' >>"$TEST_LOG"
+printf ' %q' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+touch "$PWD/yay-99-1-x86_64.pkg.tar.zst"
+EOF_MAKEPKG
+chmod +x "$fakebin/makepkg"
+
+cat >"$fakebin/systemctl" <<'EOF_SYSTEMCTL'
+#!/usr/bin/env bash
+exit 1
+EOF_SYSTEMCTL
+chmod +x "$fakebin/systemctl"
+
+export TEST_LOG="$logfile"
+export TEST_FAKEBIN="$fakebin"
+export PATH="$fakebin:/usr/bin:/bin"
+export HOME="$home"
+export USER=tester
+export AWTARCHY_RUNTIME="$runtime"
+export AWTARCHY_MANAGED_PACKAGES_FILE="${TMP}/managed-packages"
+
+# Load real reconciler functions without executing the interactive main flow.
+# The standalone collect_state call is the boundary between definitions and main.
+# shellcheck disable=SC1090
+source <(sed '/^collect_state$/,$d' "$RECONCILER")
+
+# Keep the test unprivileged while exercising the real helper-rebuild path.
+as_root() {
+  "$@"
+}
+
+if ! declare -F ensure_aur_helper >/dev/null; then
+  fail 'reconciler has no AUR-helper recovery function'
+else
+  AUR_HELPER=""
+  if ! ensure_aur_helper; then
+    fail 'broken installed AUR helper was not repaired'
+  elif [[ $AUR_HELPER != yay ]]; then
+    fail "expected repaired yay helper, got: ${AUR_HELPER:-none}"
+  elif ! yay --version >/dev/null 2>&1; then
+    fail 'repaired yay is still unusable'
+  fi
+fi
+
+if ! grep -Fq 'git clone' "$logfile" 2>/dev/null; then
+  fail 'broken yay did not trigger an AUR source rebuild'
+fi
+if ! grep -Fq 'pacman -U' "$logfile" 2>/dev/null; then
+  fail 'rebuilt yay package was not installed with pacman -U'
+fi
+
+if ! declare -F choose_ly_action >/dev/null; then
+  fail 'reconciler has no interrupted Ly setup recovery action'
+else
+  confirm_yes_no() { return 0; }
+  LY_STATUS='installed, not enabled on tty2'
+  install_ly=0
+  enable_ly=0
+  choose_ly_action
+  (( install_ly == 0 )) || fail 'already-installed Ly was incorrectly scheduled for reinstall'
+  (( enable_ly == 1 )) || fail 'installed-but-disabled Ly was not scheduled for tty2 enablement'
+fi
+
+if (( failures > 0 )); then
+  exit 1
+fi
+
+printf 'PASS: package reconciler repairs broken AUR helpers and interrupted Ly setup\n'

--- a/tests/test-package-reconciler-interrupted-recovery.sh
+++ b/tests/test-package-reconciler-interrupted-recovery.sh
@@ -137,7 +137,7 @@ if ! declare -F choose_ly_action >/dev/null; then
   fail 'reconciler has no interrupted Ly setup recovery action'
 else
   confirm_yes_no() { return 0; }
-  LY_STATUS='installed, not enabled on tty2'
+  export LY_STATUS='installed, not enabled on tty2'
   install_ly=0
   enable_ly=0
   choose_ly_action


### PR DESCRIPTION
Repairs interrupted package reconciliation when a full pacman upgrade changes libalpm and leaves an installed AUR helper unable to start.

- validates paru/yay by actually running --version
- rebuilds an installed standard helper from AUR source against current pacman/libalpm when needed
- resumes Ly tty2 setup when Ly is installed but not enabled
- performs Ly setup before the AUR stage so later package failures do not strand it again
- adds permanent red/green recovery coverage

Validated with package-reconciler regression, Bash syntax, ShellCheck, full Awtarchy updater/integration checks, PolicyKit, and theme-picker checks.