### PR TITLE
Fix AUR scanner tagged fixture checkout

### DIFF
--- a/.github/workflows/validate-direct-aur-scanner.yml
+++ b/.github/workflows/validate-direct-aur-scanner.yml
@@ -57,6 +57,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          fetch-depth: 0
 
       - name: Validate direct aur-scanner delegation
         shell: bash


### PR DESCRIPTION
Post-merge validation exposed a CI-only issue in `Validate Direct AUR Scanner`: `tests/test-aur-helper-policy.sh` reads the published `v3.5.0` fixture, but the workflow used the default shallow `actions/checkout` depth and therefore did not fetch tags.

The actual AUR installer/updater tests passed before the fixture lookup failed.

This changes the workflow checkout to `fetch-depth: 0` so tagged historical fixtures are available.