### PR TITLE
Fix Quickshell recovery bootstrap ShellCheck

### DIFF
--- a/tests/test-quickshell-updater-bootstrap.sh
+++ b/tests/test-quickshell-updater-bootstrap.sh
@@ -6,7 +6,6 @@ IFS=$'\n\t'
 ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)"
 RUNTIME="${ROOT}/local/share/awtarchy/awtarchy-runtime.sh"
 TMPD="$(mktemp -d)"
-SYSTEM_PATH="$PATH"
 REAL_CHILD_PIDS=()
 
 cleanup() {


### PR DESCRIPTION
`Validate Awtarchy` on merged commit `b0ccc6e780c6f020164eafc59582ec0c583c8941` failed only because `SYSTEM_PATH` remained unused in `tests/test-quickshell-updater-bootstrap.sh` after the real-process regression was refactored.

This removes that stale test-only assignment. No updater/runtime behavior changes.

Failure evidence: main workflow run 33821047530, ShellCheck step, SC2034.