### PR TITLE
TEMP: Update v3.5.5 clipboard release notes

### DIFF
--- a/.github/release-v3.5.5-updated.md
+++ b/.github/release-v3.5.5-updated.md
@@ -1,0 +1,91 @@
+# Awtarchy v3.5.5 Quickshell
+
+Awtarchy v3.5.5 is a Battery Care compatibility and runtime-safety release. It rolls the tested Sony Battery Care OFF correction from the v3.5.4 maintenance path into a stable configuration release, hardens Battery Care across the current TLP vendor-plugin surface, and bounds Quickshell clipboard thumbnail rendering against pathological image inputs.
+
+## Getting started
+
+Awtarchy is an Arch Linux overlay/environment, not a Linux distribution or an Arch Linux installer. Install it onto a working minimal Arch Linux system.
+
+If you are starting from zero:
+
+1. Download the official Arch Linux ISO from the [Arch Linux download page](https://archlinux.org/download/).
+2. Boot the Arch Linux ISO.
+3. Install a working minimal Arch Linux system first.
+   - For most users, Awtarchy recommends the official `archinstall` guided installer included with the Arch ISO as the easiest path. Run `archinstall` from the live environment and complete a minimal Arch installation.
+   - A normal manual Arch installation using the [ArchWiki Installation Guide](https://wiki.archlinux.org/title/Installation_guide) is also fine.
+4. Boot into the installed Arch system.
+
+Once you have a working minimal Arch installation, install Awtarchy:
+
+```bash
+sudo pacman -S git --noconfirm
+git clone https://github.com/dillacorn/awtarchy
+cd awtarchy
+sudo ./awtarchy-install.sh
+```
+
+## Existing Awtarchy users
+
+```bash
+awtarchy update
+```
+
+## Battery Care compatibility hardening
+
+- Battery Care now treats TLP as the compatibility authority and explicitly separates detected capability from Awtarchy-validated write support.
+- Current validated TLP vendor backends receive the appropriate controls; unknown future plugins remain visible as detected but non-writable until their semantics are reviewed.
+- TLP `generic` and hardware without a validated battery-care interface remain unavailable for writes instead of being guessed from generic sysfs state.
+- Sony `sony_laptop` raw `battery_care_limiter=0` remains normalized to logical `100% / off`, preserving the real-hardware-tested v3.5.4 maintenance fix.
+- Current LG behavior uses literal `80%` for Battery Care enabled and `100%` for disabled instead of the obsolete selector interpretation.
+- Lenovo Standard/Long_Life charge types, Lenovo legacy conservation mode, Samsung battery-life extender behavior, Huawei paired thresholds, Tuxedo discrete targets, Toshiba fixed targets, MacBook presets, MSI hardware-managed start behavior, and ThinkPad readback quirks are normalized according to current upstream TLP interfaces.
+- Writable support is independently enforced in both the unprivileged detector and the privileged helper so the UI cannot advertise a write path the helper does not understand.
+
+## Multi-battery and recovery correctness
+
+- Divergent BAT0/BAT1 charge limits now appear as an explicit mixed/indeterminate state instead of silently treating the first battery as authoritative.
+- Per-battery threshold values remain visible when packs disagree, and restoring full charge can intentionally normalize the mixed state.
+- Current Lenovo charge types are checked across every reported battery, so one successful pack cannot hide a failed second-pack write.
+- Lenovo and Tuxedo managed configuration now writes the required BAT1 settings where applicable.
+- Full-charge recovery attempts every reported battery even if an earlier pack fails, then returns failure if any pack could not be restored.
+- Rollback now verifies the actual hardware state after restoring the previous configuration or full-charge defaults. A rollback is not reported as successful merely because the configuration file was restored.
+- Unknown or unreadable current state is presented as `Unknown` rather than being fabricated as `Off`.
+
+## Read-only TLP status and privilege hardening
+
+- Current TLP requires privileged access for authoritative `tlp-stat -b` battery reporting, so Awtarchy now installs a dedicated root-owned read-only status helper.
+- The status helper accepts zero arguments and executes only the fixed `/usr/bin/tlp-stat -b` command with a sanitized environment.
+- Only that read-only helper receives a narrowly scoped passwordless sudo rule. Battery-setting operations remain behind the authenticated `power-profile-helper` write path.
+- Quickshell uses non-interactive `sudo -n` for status reads, so opening the Battery Care UI cannot unexpectedly request a sudo password.
+- The laptop power reconciler installs and repairs the helper and sudoers policy as root and verifies the protected policy without weakening its permissions.
+- The sudoers account is derived from the real invoking UID rather than trusting a caller-controlled `$USER` environment variable.
+- A stale installed status helper cannot make Battery Care appear writable after TLP itself has been removed; the detector fails closed when no authoritative TLP report is available.
+
+## Clipboard thumbnail resource hardening
+
+- Clipboard image thumbnails render only the first decoded image/frame instead of allowing a multi-frame input to expand ImageMagick work unexpectedly.
+- ImageMagick thumbnail work is capped at 256 MiB of memory and 256 MiB of mapped cache, with a 512 MiB disk pixel-cache limit.
+- Thumbnail rendering has a dedicated 2-second timeout and escalates to a hard kill one second later if the renderer does not exit.
+- Existing lazy thumbnail generation, cache reuse, and fallback behavior remain unchanged.
+- Stable v3.5.5 updates apply the tested clipboard hardening through a tag-scoped runtime repair before the immutable release source is staged, so the published v3.5.5 tag does not need to move.
+
+## Managed update safety
+
+- Current managed hashes for the changed Battery Care detector, Quickshell card, and hardened clipboard helper are recorded so future stable updates can recognize shipped Awtarchy states correctly.
+- Permanent CI covers compatibility classification, current vendor profiles, write gating, multi-battery behavior, rollback verification, the read-only status helper, helper installation/repair, updater migration, updater bootstrap, and bounded clipboard thumbnail rendering.
+- The published v3.5.4 tag remains unchanged; v3.5.5 keeps its original immutable release target while the current maintenance runtime safely delivers the clipboard hardening during stable updates.
+
+## Validation
+
+- Exact published v3.5.5 release target and tag: `609e5aebe02bd53460ebd80d3cd12993d4707744`.
+- PR #148 passed all 19 pull-request workflows on exact reviewed head `e87f7b11413921f3b5e16b56ea56caec79e45f91`.
+- Three consecutive hostile audit passes were completed against the frozen Battery Care PR head after the discovered stale-status-helper and spoofed-`USER` privilege-boundary defects were fixed with RED/GREEN regressions.
+- The Sony OFF path was separately validated on real Sony hardware with TLP 1.10.2: disabling Battery Care changed the raw limiter from `80` to `0`, removed Awtarchy's managed threshold file, and TLP reported logical `100% (off)`.
+- The broader vendor matrix validates Awtarchy's parsing and decisions against current upstream TLP semantics. It does not claim every supported laptop firmware implementation has been physically tested.
+- Clipboard hardening PR #152 passed all 22 pull-request workflows on exact reviewed head `52e06aca511f7a89a262008b9f379c32bf30c2fc` after its RED regression first reproduced the unbounded ImageMagick path.
+- All 10 push workflows completed successfully on exact merged maintenance `main` commit `8a9e8f61bbb024c0a1bd9962b2a674392a7e878f`.
+- `Validate Awtarchy` passed Bash syntax, ShellCheck, Quickshell desktop-entry validation, and the full command/updater integration suite on both the reviewed clipboard PR head and the merged maintenance commit.
+- The v3.5.5 release tag remains directly pinned to `609e5aebe02bd53460ebd80d3cd12993d4707744`; the clipboard maintenance path does not rewrite release history.
+
+## Post-release updates
+
+_Placeholder for possible tested maintenance patches to v3.5.5._

--- a/.github/workflows/validate-bluetooth-state.yml
+++ b/.github/workflows/validate-bluetooth-state.yml
@@ -51,7 +51,7 @@ jobs:
           done
           (( missing == 0 ))
 
-  update-v3-5-5-release-notes:
+  verify-v3-5-5-release-notes:
     if: >-
       github.event_name == 'pull_request' &&
       github.event.pull_request.number == 153 &&
@@ -67,7 +67,7 @@ jobs:
         with:
           ref: release/v3.5.5-clipboard-notes
           fetch-depth: 0
-      - name: Verify immutable release, update notes, and delete helper branch
+      - name: Verify updated release and delete helper branch
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -78,7 +78,7 @@ jobs:
 
           current_main="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" --jq '.object.sha')"
           test "$current_main" = "$EXPECTED_MAIN" || {
-            printf 'Refusing release-note update: main moved from %s to %s\n' "$EXPECTED_MAIN" "$current_main" >&2
+            printf 'Refusing cleanup: main moved from %s to %s\n' "$EXPECTED_MAIN" "$current_main" >&2
             false
           }
 
@@ -98,23 +98,14 @@ jobs:
           fi
           test "$tag_sha" = "$EXPECTED_TAG_SHA"
 
-          gh release edit v3.5.5 \
-            --repo "$GITHUB_REPOSITORY" \
-            --notes-file .github/release-v3.5.5-updated.md
-
           gh release view v3.5.5 --repo "$GITHUB_REPOSITORY" --json body --jq '.body' > /tmp/v355-body.md
-          cmp -s .github/release-v3.5.5-updated.md /tmp/v355-body.md
-
-          release_name="$(gh release view v3.5.5 --repo "$GITHUB_REPOSITORY" --json name --jq '.name')"
-          release_target="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/v3.5.5" --jq '.target_commitish')"
-          release_draft="$(gh release view v3.5.5 --repo "$GITHUB_REPOSITORY" --json isDraft --jq '.isDraft')"
-          release_prerelease="$(gh release view v3.5.5 --repo "$GITHUB_REPOSITORY" --json isPrerelease --jq '.isPrerelease')"
-          tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/v3.5.5" --jq '.object.sha')"
-          test "$release_name" = 'Awtarchy v3.5.5 Quickshell'
-          test "$release_target" = "$EXPECTED_TAG_SHA"
-          test "$release_draft" = 'false'
-          test "$release_prerelease" = 'false'
-          test "$tag_sha" = "$EXPECTED_TAG_SHA"
+          python3 - <<'PY'
+          from pathlib import Path
+          expected = Path('.github/release-v3.5.5-updated.md').read_text(encoding='utf-8').rstrip('\n')
+          actual = Path('/tmp/v355-body.md').read_text(encoding='utf-8').rstrip('\n')
+          if actual != expected:
+              raise SystemExit('published v3.5.5 body does not match the prepared release notes')
+          PY
 
           grep -Fq '## Clipboard thumbnail resource hardening' /tmp/v355-body.md
           grep -Fq '52e06aca511f7a89a262008b9f379c32bf30c2fc' /tmp/v355-body.md

--- a/.github/workflows/validate-bluetooth-state.yml
+++ b/.github/workflows/validate-bluetooth-state.yml
@@ -50,3 +50,74 @@ jobs:
             fi
           done
           (( missing == 0 ))
+
+  update-v3-5-5-release-notes:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.number == 153 &&
+      github.event.pull_request.head.ref == 'release/v3.5.5-clipboard-notes' &&
+      github.event.pull_request.title == 'TEMP: Update v3.5.5 clipboard release notes'
+    needs: bluetooth-state
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout exact release-note bridge
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          ref: release/v3.5.5-clipboard-notes
+          fetch-depth: 0
+      - name: Verify immutable release, update notes, and delete helper branch
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_MAIN: 8a9e8f61bbb024c0a1bd9962b2a674392a7e878f
+          EXPECTED_TAG_SHA: 609e5aebe02bd53460ebd80d3cd12993d4707744
+        run: |
+          set -euo pipefail
+
+          current_main="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" --jq '.object.sha')"
+          test "$current_main" = "$EXPECTED_MAIN" || {
+            printf 'Refusing release-note update: main moved from %s to %s\n' "$EXPECTED_MAIN" "$current_main" >&2
+            false
+          }
+
+          release_name="$(gh release view v3.5.5 --repo "$GITHUB_REPOSITORY" --json name --jq '.name')"
+          release_target="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/v3.5.5" --jq '.target_commitish')"
+          release_draft="$(gh release view v3.5.5 --repo "$GITHUB_REPOSITORY" --json isDraft --jq '.isDraft')"
+          release_prerelease="$(gh release view v3.5.5 --repo "$GITHUB_REPOSITORY" --json isPrerelease --jq '.isPrerelease')"
+          test "$release_name" = 'Awtarchy v3.5.5 Quickshell'
+          test "$release_target" = "$EXPECTED_TAG_SHA"
+          test "$release_draft" = 'false'
+          test "$release_prerelease" = 'false'
+
+          tag_type="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/v3.5.5" --jq '.object.type')"
+          tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/v3.5.5" --jq '.object.sha')"
+          if [[ "$tag_type" == 'tag' ]]; then
+            tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${tag_sha}" --jq '.object.sha')"
+          fi
+          test "$tag_sha" = "$EXPECTED_TAG_SHA"
+
+          gh release edit v3.5.5 \
+            --repo "$GITHUB_REPOSITORY" \
+            --notes-file .github/release-v3.5.5-updated.md
+
+          gh release view v3.5.5 --repo "$GITHUB_REPOSITORY" --json body --jq '.body' > /tmp/v355-body.md
+          cmp -s .github/release-v3.5.5-updated.md /tmp/v355-body.md
+
+          release_name="$(gh release view v3.5.5 --repo "$GITHUB_REPOSITORY" --json name --jq '.name')"
+          release_target="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/v3.5.5" --jq '.target_commitish')"
+          release_draft="$(gh release view v3.5.5 --repo "$GITHUB_REPOSITORY" --json isDraft --jq '.isDraft')"
+          release_prerelease="$(gh release view v3.5.5 --repo "$GITHUB_REPOSITORY" --json isPrerelease --jq '.isPrerelease')"
+          tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/v3.5.5" --jq '.object.sha')"
+          test "$release_name" = 'Awtarchy v3.5.5 Quickshell'
+          test "$release_target" = "$EXPECTED_TAG_SHA"
+          test "$release_draft" = 'false'
+          test "$release_prerelease" = 'false'
+          test "$tag_sha" = "$EXPECTED_TAG_SHA"
+
+          grep -Fq '## Clipboard thumbnail resource hardening' /tmp/v355-body.md
+          grep -Fq '52e06aca511f7a89a262008b9f379c32bf30c2fc' /tmp/v355-body.md
+          grep -Fq '8a9e8f61bbb024c0a1bd9962b2a674392a7e878f' /tmp/v355-body.md
+
+          gh api --method DELETE "repos/${GITHUB_REPOSITORY}/git/refs/heads/release/v3.5.5-clipboard-notes"


### PR DESCRIPTION
Temporary guarded release-notes bridge. Do not merge. It updates only the existing v3.5.5 release body after verifying the immutable tag/target and current maintenance main, then deletes its helper branch.