### PR TITLE
Harden battery telemetry against phantom packs

### DIFF
--- a/config/hypr/scripts/quickshell_battery_telemetry.sh
+++ b/config/hypr/scripts/quickshell_battery_telemetry.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# Read-only raw battery telemetry correction for Awtarchy Quickshell.
+# UPower remains authoritative unless a multi-battery system contains a pack
+# that is unambiguously electrically dead/phantom from raw sysfs evidence.
+
+set -euo pipefail
+export LC_ALL=C
+
+POWER_SUPPLY_ROOT="${AWTARCHY_POWER_SUPPLY_ROOT:-/sys/class/power_supply}"
+
+usage() {
+    printf 'usage: %s --status-json\n' "${0##*/}" >&2
+    return 2
+}
+
+read_text() {
+    local path="$1"
+    [[ -r "$path" ]] || return 1
+    tr -d '\r\n' <"$path"
+}
+
+read_nonnegative_integer() {
+    local path="$1" value
+    value="$(read_text "$path" 2>/dev/null || true)"
+    [[ "$value" =~ ^[0-9]+$ ]] || return 1
+    printf '%s\n' "$value"
+}
+
+read_signed_integer() {
+    local path="$1" value
+    value="$(read_text "$path" 2>/dev/null || true)"
+    [[ "$value" =~ ^-?[0-9]+$ ]] || return 1
+    printf '%s\n' "$value"
+}
+
+abs_integer() {
+    local value="$1"
+    if [[ "$value" == -* ]]; then
+        printf '%s\n' "${value#-}"
+    else
+        printf '%s\n' "$value"
+    fi
+}
+
+json_array() {
+    jq -cn --args '$ARGS.positional' "$@"
+}
+
+emit_fallback() {
+    local reason="$1"
+    local excluded_json included_json
+    excluded_json="$(json_array)"
+    included_json="$(json_array)"
+    jq -cn \
+        --arg reason "$reason" \
+        --argjson excluded "$excluded_json" \
+        --argjson included "$included_json" '
+        {
+            override:false,
+            reason:$reason,
+            percentage:null,
+            energy_wh:null,
+            energy_capacity_wh:null,
+            change_rate_watts:null,
+            time_to_empty_seconds:null,
+            time_to_full_seconds:null,
+            excluded:$excluded,
+            included:$included
+        }'
+}
+
+main() {
+    [[ ${1:-} == --status-json && $# -eq 1 ]] || { usage; return 2; }
+    command -v jq >/dev/null 2>&1 || return 127
+
+    local present_count=0 unknown=false
+    local battery_dir type name present voltage
+    local energy_now energy_full charge_now charge_full stored_now stored_full storage_kind
+    local power current power_abs current_abs pack_energy_now pack_energy_full pack_power value
+    local total_now=0 total_full=0 total_power=0
+    local percentage energy_wh energy_capacity_wh change_rate_watts
+    local time_to_empty_seconds=0 time_to_full_seconds=0 excluded_json included_json
+    local -a dead_names=()
+    local -a included_names=()
+    local -a included_energy_now=()
+    local -a included_energy_full=()
+    local -a included_power_now=()
+
+    shopt -s nullglob
+    for battery_dir in "$POWER_SUPPLY_ROOT"/*; do
+        [[ -d "$battery_dir" ]] || continue
+        type="$(read_text "$battery_dir/type" 2>/dev/null || true)"
+        [[ "$type" == Battery ]] || continue
+
+        name="${battery_dir##*/}"
+        present="$(read_nonnegative_integer "$battery_dir/present" 2>/dev/null || true)"
+        if [[ "$present" != 0 && "$present" != 1 ]]; then
+            unknown=true
+            continue
+        fi
+        [[ "$present" == 1 ]] || continue
+        ((present_count += 1))
+
+        voltage="$(read_nonnegative_integer "$battery_dir/voltage_now" 2>/dev/null || true)"
+        if [[ -z "$voltage" ]]; then
+            unknown=true
+            continue
+        fi
+
+        energy_now="$(read_nonnegative_integer "$battery_dir/energy_now" 2>/dev/null || true)"
+        energy_full="$(read_nonnegative_integer "$battery_dir/energy_full" 2>/dev/null || true)"
+        charge_now="$(read_nonnegative_integer "$battery_dir/charge_now" 2>/dev/null || true)"
+        charge_full="$(read_nonnegative_integer "$battery_dir/charge_full" 2>/dev/null || true)"
+
+        stored_now=""
+        stored_full=""
+        storage_kind=""
+        if [[ -n "$energy_now" && -n "$energy_full" && "$energy_full" -gt 0 ]]; then
+            stored_now="$energy_now"
+            stored_full="$energy_full"
+            storage_kind="energy"
+        elif [[ -n "$charge_now" && -n "$charge_full" && "$charge_full" -gt 0 ]]; then
+            stored_now="$charge_now"
+            stored_full="$charge_full"
+            storage_kind="charge"
+        else
+            unknown=true
+            continue
+        fi
+
+        power="$(read_signed_integer "$battery_dir/power_now" 2>/dev/null || true)"
+        current="$(read_signed_integer "$battery_dir/current_now" 2>/dev/null || true)"
+        if [[ -z "$power" && -z "$current" ]]; then
+            unknown=true
+            continue
+        fi
+
+        power_abs=""
+        current_abs=""
+        [[ -z "$power" ]] || power_abs="$(abs_integer "$power")"
+        [[ -z "$current" ]] || current_abs="$(abs_integer "$current")"
+
+        if [[ "$voltage" -eq 0 ]]; then
+            # A dead/phantom classification requires a stale positive capacity
+            # plus zero present charge/energy and zero observed electrical flow.
+            # Any contradictory or missing signal fails closed to UPower.
+            if [[ "$stored_now" -eq 0 \
+                && ( -z "$power_abs" || "$power_abs" -eq 0 ) \
+                && ( -z "$current_abs" || "$current_abs" -eq 0 ) ]]; then
+                dead_names+=("$name")
+                continue
+            fi
+            unknown=true
+            continue
+        fi
+
+        # Nonzero voltage means an empty 0%-equivalent pack is still real
+        # hardware. It stays included. Charge-domain telemetry is converted only
+        # with observed voltage so all included packs share energy-domain units.
+        if [[ "$storage_kind" == energy ]]; then
+            pack_energy_now="$stored_now"
+            pack_energy_full="$stored_full"
+        else
+            pack_energy_now="$(awk -v q="$stored_now" -v v="$voltage" 'BEGIN { printf "%.0f", (q * v) / 1000000 }')"
+            pack_energy_full="$(awk -v q="$stored_full" -v v="$voltage" 'BEGIN { printf "%.0f", (q * v) / 1000000 }')"
+        fi
+
+        if [[ -n "$power_abs" ]]; then
+            pack_power="$power_abs"
+        else
+            pack_power="$(awk -v i="$current_abs" -v v="$voltage" 'BEGIN { printf "%.0f", (i * v) / 1000000 }')"
+        fi
+
+        if [[ ! "$pack_energy_full" =~ ^[0-9]+$ || "$pack_energy_full" -le 0 \
+            || ! "$pack_energy_now" =~ ^[0-9]+$ || ! "$pack_power" =~ ^[0-9]+$ ]]; then
+            unknown=true
+            continue
+        fi
+
+        included_names+=("$name")
+        included_energy_now+=("$pack_energy_now")
+        included_energy_full+=("$pack_energy_full")
+        included_power_now+=("$pack_power")
+    done
+
+    if (( present_count < 2 )); then
+        emit_fallback "single-battery"
+        return 0
+    fi
+
+    if [[ "$unknown" == true ]]; then
+        emit_fallback "insufficient-telemetry"
+        return 0
+    fi
+
+    if (( ${#dead_names[@]} == 0 )); then
+        emit_fallback "no-dead-pack"
+        return 0
+    fi
+
+    if (( ${#included_names[@]} == 0 )); then
+        emit_fallback "insufficient-telemetry"
+        return 0
+    fi
+
+    for value in "${included_energy_now[@]}"; do
+        total_now=$((total_now + value))
+    done
+    for value in "${included_energy_full[@]}"; do
+        total_full=$((total_full + value))
+    done
+    for value in "${included_power_now[@]}"; do
+        total_power=$((total_power + value))
+    done
+
+    if (( total_full <= 0 || total_now < 0 || total_now > total_full || total_power < 0 )); then
+        emit_fallback "insufficient-telemetry"
+        return 0
+    fi
+
+    percentage="$(awk -v now="$total_now" -v full="$total_full" 'BEGIN { printf "%d", ((now / full) * 100) + 0.5 }')"
+    energy_wh="$(awk -v value="$total_now" 'BEGIN { printf "%.6f", value / 1000000 }')"
+    energy_capacity_wh="$(awk -v value="$total_full" 'BEGIN { printf "%.6f", value / 1000000 }')"
+    change_rate_watts="$(awk -v value="$total_power" 'BEGIN { printf "%.6f", value / 1000000 }')"
+    if (( total_power > 0 )); then
+        time_to_empty_seconds="$(awk -v now="$total_now" -v power="$total_power" 'BEGIN { printf "%.0f", (now / power) * 3600 }')"
+        time_to_full_seconds="$(awk -v now="$total_now" -v full="$total_full" -v power="$total_power" 'BEGIN { printf "%.0f", ((full - now) / power) * 3600 }')"
+    fi
+
+    excluded_json="$(json_array "${dead_names[@]}")"
+    included_json="$(json_array "${included_names[@]}")"
+
+    jq -cn \
+        --argjson percentage "$percentage" \
+        --argjson energy_wh "$energy_wh" \
+        --argjson energy_capacity_wh "$energy_capacity_wh" \
+        --argjson change_rate_watts "$change_rate_watts" \
+        --argjson time_to_empty_seconds "$time_to_empty_seconds" \
+        --argjson time_to_full_seconds "$time_to_full_seconds" \
+        --argjson excluded "$excluded_json" \
+        --argjson included "$included_json" '
+        {
+            override:true,
+            reason:"dead-or-phantom-pack",
+            percentage:$percentage,
+            energy_wh:$energy_wh,
+            energy_capacity_wh:$energy_capacity_wh,
+            change_rate_watts:$change_rate_watts,
+            time_to_empty_seconds:$time_to_empty_seconds,
+            time_to_full_seconds:$time_to_full_seconds,
+            excluded:$excluded,
+            included:$included
+        }'
+}
+
+main "$@"

--- a/config/quickshell/awtarchy/BatteryState.qml
+++ b/config/quickshell/awtarchy/BatteryState.qml
@@ -2,23 +2,50 @@ pragma Singleton
 
 import QtQuick
 import Quickshell
+import Quickshell.Io
 import Quickshell.Services.UPower
 
 Singleton {
     id: root
 
+    property var telemetryData: emptyTelemetry()
+
     readonly property var device: UPower.displayDevice
     readonly property bool available: device.ready && device.isLaptopBattery
+    readonly property string configHome: Quickshell.env("XDG_CONFIG_HOME")
+        || (Quickshell.env("HOME") + "/.config")
+    readonly property string batteryTelemetryScript: configHome
+        + "/hypr/scripts/quickshell_battery_telemetry.sh"
+    readonly property bool telemetryOverrideActive: available && telemetryData.override === true
+    readonly property int telemetryPercentage: telemetryOverrideActive
+        ? Math.round(Number(telemetryData.percentage)) : 0
+    readonly property real telemetryTimeToEmptySeconds: telemetryOverrideActive
+        ? validSeconds(telemetryData.time_to_empty_seconds) : 0
+    readonly property real telemetryTimeToFullSeconds: telemetryOverrideActive
+        ? validSeconds(telemetryData.time_to_full_seconds) : 0
+    readonly property real telemetryEnergyWh: telemetryOverrideActive
+        ? validNonNegative(telemetryData.energy_wh) : 0
+    readonly property real telemetryEnergyCapacityWh: telemetryOverrideActive
+        ? validNonNegative(telemetryData.energy_capacity_wh) : 0
+    readonly property real telemetryChangeRateWatts: telemetryOverrideActive
+        ? validNonNegative(telemetryData.change_rate_watts) : 0
     readonly property int percentage: available
-        ? Math.max(0, Math.min(100, Math.round(Number(device.percentage) * 100))) : 0
+        ? (telemetryOverrideActive ? telemetryPercentage
+            : Math.max(0, Math.min(100, Math.round(Number(device.percentage) * 100)))) : 0
     readonly property bool onBattery: available && UPower.onBattery
     readonly property bool pluggedIn: available && !UPower.onBattery
     readonly property int state: available ? device.state : UPowerDeviceState.Unknown
-    readonly property real timeToEmptySeconds: available ? validSeconds(device.timeToEmpty) : 0
-    readonly property real timeToFullSeconds: available ? validSeconds(device.timeToFull) : 0
-    readonly property real energyWh: available ? validNonNegative(device.energy) : 0
-    readonly property real energyCapacityWh: available ? validNonNegative(device.energyCapacity) : 0
-    readonly property real changeRateWatts: available ? validNumber(device.changeRate) : 0
+    readonly property real timeToEmptySeconds: available
+        ? (telemetryOverrideActive ? telemetryTimeToEmptySeconds : validSeconds(device.timeToEmpty)) : 0
+    readonly property real timeToFullSeconds: available
+        ? (telemetryOverrideActive ? telemetryTimeToFullSeconds : validSeconds(device.timeToFull)) : 0
+    readonly property real energyWh: available
+        ? (telemetryOverrideActive ? telemetryEnergyWh : validNonNegative(device.energy)) : 0
+    readonly property real energyCapacityWh: available
+        ? (telemetryOverrideActive ? telemetryEnergyCapacityWh
+            : validNonNegative(device.energyCapacity)) : 0
+    readonly property real changeRateWatts: available
+        ? (telemetryOverrideActive ? telemetryChangeRateWatts : validNumber(device.changeRate)) : 0
     readonly property bool healthSupported: available && Boolean(device.healthSupported)
     readonly property int healthPercentage: healthSupported
         ? Math.max(0, Math.min(100, Math.round(validNonNegative(device.healthPercentage)))) : 0
@@ -45,6 +72,51 @@ Singleton {
 
     function validSeconds(value) {
         return Math.max(0, validNumber(value));
+    }
+
+    function emptyTelemetry() {
+        return ({ override: false });
+    }
+
+    function sanitizedTelemetry(data) {
+        if (!data || data.override !== true)
+            return emptyTelemetry();
+
+        const percentageValue = Number(data.percentage);
+        const energyValue = Number(data.energy_wh);
+        const capacityValue = Number(data.energy_capacity_wh);
+        const rateValue = Number(data.change_rate_watts);
+        const emptySecondsValue = Number(data.time_to_empty_seconds);
+        const fullSecondsValue = Number(data.time_to_full_seconds);
+        const excluded = Array.isArray(data.excluded) ? data.excluded : [];
+        const included = Array.isArray(data.included) ? data.included : [];
+
+        if (!Number.isFinite(percentageValue) || percentageValue < 0 || percentageValue > 100
+            || !Number.isFinite(energyValue) || energyValue < 0
+            || !Number.isFinite(capacityValue) || capacityValue <= 0 || energyValue > capacityValue
+            || !Number.isFinite(rateValue) || rateValue < 0
+            || !Number.isFinite(emptySecondsValue) || emptySecondsValue < 0
+            || !Number.isFinite(fullSecondsValue) || fullSecondsValue < 0
+            || excluded.length === 0 || included.length === 0)
+            return emptyTelemetry();
+
+        return ({
+            override: true,
+            percentage: Math.round(percentageValue),
+            energy_wh: energyValue,
+            energy_capacity_wh: capacityValue,
+            change_rate_watts: rateValue,
+            time_to_empty_seconds: emptySecondsValue,
+            time_to_full_seconds: fullSecondsValue
+        });
+    }
+
+    function refreshTelemetry() {
+        if (!available || batteryTelemetryReader.running)
+            return;
+        batteryTelemetryReader.exec([
+            "/usr/bin/bash", batteryTelemetryScript, "--status-json"
+        ]);
     }
 
     function formatDuration(seconds) {
@@ -122,5 +194,38 @@ Singleton {
             lines.push("Plugged in");
 
         return lines.join("\n");
+    }
+
+    onAvailableChanged: {
+        telemetryData = emptyTelemetry();
+        if (available)
+            refreshTelemetry();
+    }
+
+    Component.onCompleted: refreshTelemetry()
+
+    Process {
+        id: batteryTelemetryReader
+        stdout: StdioCollector {
+            onStreamFinished: {
+                try {
+                    const parsed = JSON.parse(text.trim() || "{}");
+                    root.telemetryData = root.sanitizedTelemetry(parsed);
+                } catch (error) {
+                    root.telemetryData = root.emptyTelemetry();
+                }
+            }
+        }
+        onExited: (exitCode, exitStatus) => {
+            if (exitCode !== 0)
+                root.telemetryData = root.emptyTelemetry();
+        }
+    }
+
+    Timer {
+        interval: 15000
+        repeat: true
+        running: root.available
+        onTriggered: root.refreshTelemetry()
     }
 }

--- a/local/share/awtarchy/quickshell-managed-history.sha256
+++ b/local/share/awtarchy/quickshell-managed-history.sha256
@@ -1,4 +1,3 @@
-
 # Current Quickshell managed stock hashes refreshed by updater-policy validation.
 # Current testing-branch hashes are appended so the next release can identify them.
 # Cursor-preserving launcher keyboard-focus correction.
@@ -46,7 +45,7 @@
 146ff83d178cc4c2082ea250223892c922953cfa61aabaa3fb9cdc79219bbd0e	.config/hypr/scripts/quickshell_clipboard.sh
 1540173cccc05bb191fb6f8df4b39bb249428b601ab3b22aeb995b30375c7051	.config/hypr/scripts/quickshell_flyout_prepare.sh
 160f65419d4aafacdd9bd07b3d90ac62bdebfc145e2dbaa3ce2dac64ab928a7d	.config/quickshell/awtarchy/Theme.qml
-164f0fc8b1a26307797b125b406bf8fa8b15da55b7dc86a4ac666c6fa670a50f	.config/quickshell/awtarchy/ThemePicker.qml
+164f0fc8b5731927d0b2ba80bab3ad6c5298cbd49e88128e21527bd7913c75bd	.config/quickshell/awtarchy/ThemePicker.qml
 1699801a96eeca73ec4b87fd21437d04d99ea5328320acde4c95a841be327b8c	.config/hypr/scripts/quickshell_runtime_rules.sh
 173f964b1e57e028b4efef94ef74b9b17a10eab2dd485eae9e615fcf8b557dc0	.config/hypr/scripts/quickshell_clipboard.sh
 185dc3aa8a786111814e54568e1c60d931c286f5a52615702475889fc1a04368	.config/quickshell/awtarchy/FlyoutSettings.qml
@@ -862,3 +861,7 @@ b9f4443a55ed4cef9f56b147726ee07928e21f44ce3fa5eccbbc3b3a9a9cfb63	.config/quicksh
 e2f9bfc815421e0732fa1a9b9d317343655a1f8f2137e7e5827ebe6e28dc90af	.config/hypr/scripts/quickshell_battery_care.sh
 8891de8271fa22f3932e7f9ee355c47f0807ab27f1151c77abf54bf10603fd02	.config/hypr/scripts/quickshell_clipboard.sh
 ab73a9056ecd3cd692112cf218464c9abe1de5792b0fdaad1f6401b063a0d967	.config/hypr/scripts/quickshell_clipboard.sh
+
+# 2026-09-05 phantom battery telemetry correction.
+47e867d2068784aa6850deb4c9e9c014f24110458378534724dc00546040a86c	.config/hypr/scripts/quickshell_battery_telemetry.sh
+e510b4b5ec3262870d7c9a9551e5a9e07fd30ae93416818b8578270aa42a31a0	.config/quickshell/awtarchy/BatteryState.qml

--- a/local/share/awtarchy/quickshell-managed-history.sha256
+++ b/local/share/awtarchy/quickshell-managed-history.sha256
@@ -1,3 +1,4 @@
+
 # Current Quickshell managed stock hashes refreshed by updater-policy validation.
 # Current testing-branch hashes are appended so the next release can identify them.
 # Cursor-preserving launcher keyboard-focus correction.
@@ -45,7 +46,7 @@
 146ff83d178cc4c2082ea250223892c922953cfa61aabaa3fb9cdc79219bbd0e	.config/hypr/scripts/quickshell_clipboard.sh
 1540173cccc05bb191fb6f8df4b39bb249428b601ab3b22aeb995b30375c7051	.config/hypr/scripts/quickshell_flyout_prepare.sh
 160f65419d4aafacdd9bd07b3d90ac62bdebfc145e2dbaa3ce2dac64ab928a7d	.config/quickshell/awtarchy/Theme.qml
-164f0fc8b5731927d0b2ba80bab3ad6c5298cbd49e88128e21527bd7913c75bd	.config/quickshell/awtarchy/ThemePicker.qml
+164f0fc8b1a26307797b125b406bf8fa8b15da55b7dc86a4ac666c6fa670a50f	.config/quickshell/awtarchy/ThemePicker.qml
 1699801a96eeca73ec4b87fd21437d04d99ea5328320acde4c95a841be327b8c	.config/hypr/scripts/quickshell_runtime_rules.sh
 173f964b1e57e028b4efef94ef74b9b17a10eab2dd485eae9e615fcf8b557dc0	.config/hypr/scripts/quickshell_clipboard.sh
 185dc3aa8a786111814e54568e1c60d931c286f5a52615702475889fc1a04368	.config/quickshell/awtarchy/FlyoutSettings.qml

--- a/tests/test-battery-state.sh
+++ b/tests/test-battery-state.sh
@@ -4,6 +4,9 @@ set -Eeuo pipefail
 ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 STATE="${ROOT}/config/quickshell/awtarchy/BatteryState.qml"
 BAR="${ROOT}/config/quickshell/awtarchy/Bar.qml"
+HELPER="${ROOT}/config/hypr/scripts/quickshell_battery_telemetry.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf -- "$TMP"' EXIT
 
 fail() {
   printf 'FAIL: %s\n' "$*" >&2
@@ -43,4 +46,103 @@ fi
 [[ "$(grep -Fc 'tooltip: BatteryState.barTooltip' "$BAR")" -eq 2 ]] \
   || fail 'horizontal and vertical battery controls are not both using the ETA tooltip'
 
-printf '%s\n' 'PASS: battery telemetry and ETA tooltip are centralized through BatteryState.'
+# Regression contract for issue #150. The helper is deliberately read-only and
+# must only override UPower DisplayDevice when raw sysfs evidence makes a dead
+# or phantom pack unambiguous. A normal or uncertain system stays on UPower.
+[[ -f "$HELPER" ]] || fail 'battery telemetry override helper is missing'
+grep -Fq 'AWTARCHY_POWER_SUPPLY_ROOT' "$HELPER" \
+  || fail 'battery telemetry helper cannot be exercised against fixture sysfs data'
+grep -Fq 'readonly property bool telemetryOverrideActive:' "$STATE" \
+  || fail 'BatteryState does not expose conservative telemetry override state'
+grep -Fq 'quickshell_battery_telemetry.sh' "$STATE" \
+  || fail 'BatteryState does not invoke the raw battery telemetry helper'
+grep -Fq 'telemetryOverrideActive ? telemetryPercentage' "$STATE" \
+  || fail 'BatteryState percentage does not use the validated override'
+grep -Fq 'telemetryOverrideActive ? telemetryTimeToEmptySeconds' "$STATE" \
+  || fail 'BatteryState time-to-empty does not use the validated override'
+grep -Fq 'telemetryOverrideActive ? telemetryTimeToFullSeconds' "$STATE" \
+  || fail 'BatteryState time-to-full does not use the validated override'
+
+make_battery() {
+  local root="$1" name="$2" present="$3" voltage="$4" energy_now="$5" energy_full="$6" power_now="$7"
+  local dir="$root/$name"
+  mkdir -p -- "$dir"
+  printf '%s\n' Battery >"$dir/type"
+  [[ "$present" == - ]] || printf '%s\n' "$present" >"$dir/present"
+  [[ "$voltage" == - ]] || printf '%s\n' "$voltage" >"$dir/voltage_now"
+  [[ "$energy_now" == - ]] || printf '%s\n' "$energy_now" >"$dir/energy_now"
+  [[ "$energy_full" == - ]] || printf '%s\n' "$energy_full" >"$dir/energy_full"
+  [[ "$power_now" == - ]] || printf '%s\n' "$power_now" >"$dir/power_now"
+}
+
+run_helper() {
+  local root="$1"
+  AWTARCHY_POWER_SUPPLY_ROOT="$root" /usr/bin/bash "$HELPER" --status-json
+}
+
+assert_json() {
+  local json="$1" filter="$2" message="$3"
+  jq -e "$filter" <<<"$json" >/dev/null || fail "$message: $json"
+}
+
+# 1. Two healthy batteries: UPower remains authoritative.
+fixture="$TMP/healthy-dual"
+mkdir -p -- "$fixture"
+make_battery "$fixture" BAT0 1 12000000 20000000 40000000 6000000
+make_battery "$fixture" BAT1 1 11800000 10000000 20000000 4000000
+json="$(run_helper "$fixture")"
+assert_json "$json" '.override == false and .excluded == []' \
+  'healthy dual-battery fixture incorrectly enabled the override'
+
+# 2. A genuinely empty battery still has plausible voltage and must stay in the
+# aggregate. Zero percent/zero energy alone is never dead-pack evidence.
+fixture="$TMP/healthy-empty"
+mkdir -p -- "$fixture"
+make_battery "$fixture" BAT0 1 11100000 0 40000000 0
+make_battery "$fixture" BAT1 1 11900000 20000000 40000000 5000000
+json="$(run_helper "$fixture")"
+assert_json "$json" '.override == false and .excluded == []' \
+  'healthy empty battery was mistaken for a phantom pack'
+
+# 3. Electrically dead BAT0: present, stale full capacity, but zero volts,
+# zero stored energy and zero electrical flow. Only healthy BAT1 may feed the
+# correction. The helper also supplies corrected ETA inputs/estimates.
+fixture="$TMP/dead-plus-healthy"
+mkdir -p -- "$fixture"
+make_battery "$fixture" BAT0 1 0 0 40000000 0
+make_battery "$fixture" BAT1 1 12000000 20000000 40000000 10000000
+json="$(run_helper "$fixture")"
+assert_json "$json" '
+  .override == true
+  and .reason == "dead-or-phantom-pack"
+  and .excluded == ["BAT0"]
+  and .included == ["BAT1"]
+  and .percentage == 50
+  and .energy_wh == 20
+  and .energy_capacity_wh == 40
+  and .change_rate_watts == 10
+  and .time_to_empty_seconds == 7200
+  and .time_to_full_seconds == 7200
+' 'dead battery did not produce the expected healthy-pack telemetry override'
+
+# 4. Single-battery systems are never reinterpreted by this workaround, even
+# when the lone pack looks electrically dead. There is no second pack proving
+# that DisplayDevice is being poisoned by a phantom member.
+fixture="$TMP/single"
+mkdir -p -- "$fixture"
+make_battery "$fixture" BAT0 1 0 0 40000000 0
+json="$(run_helper "$fixture")"
+assert_json "$json" '.override == false and .excluded == []' \
+  'single-battery system incorrectly enabled phantom-pack override'
+
+# 5. Missing raw evidence must fail closed to UPower. This pack lacks voltage,
+# so the helper is not allowed to infer that zero energy/power means dead.
+fixture="$TMP/unknown"
+mkdir -p -- "$fixture"
+make_battery "$fixture" BAT0 1 - 0 40000000 0
+make_battery "$fixture" BAT1 1 12000000 20000000 40000000 10000000
+json="$(run_helper "$fixture")"
+assert_json "$json" '.override == false and .reason == "insufficient-telemetry" and .excluded == []' \
+  'insufficient telemetry did not fall back to UPower'
+
+printf '%s\n' 'PASS: battery telemetry and ETA are centralized with conservative phantom-pack correction.'


### PR DESCRIPTION
Closes #150.

## What changed
- added fixture-backed regression coverage for healthy dual batteries, a healthy empty 0% battery, a dead/phantom 0 V pack plus a healthy pack, single-battery systems, and insufficient telemetry;
- added a read-only raw sysfs helper that only enables an override when a multi-battery pack is unambiguously dead/phantom from 0 V, zero stored energy/charge, zero observed electrical flow, and stale positive full capacity;
- kept UPower `DisplayDevice` authoritative for normal, single-battery, healthy-empty, missing, or contradictory telemetry;
- wired only validated helper output into `BatteryState.qml` for corrected percentage, energy/rate, and ETA inputs;
- preserved Battery Care/TLP write semantics unchanged;
- recorded the new managed stock hashes without altering prior managed-history entries.

## TDD / validation
- RED: test-only commit `495c61b70019e50cdd707802be3f1a9e364cd6cc` caused `Validate Awtarchy` to fail before the helper existed;
- GREEN: exact head `167ec14e82900f291ae10e92abcf593bfd18da5f` passes `Validate Awtarchy` and the full PR workflow set;
- updater-policy validation also verifies the managed-history entries.

No real-hardware runtime claim is made; the fix is intentionally conservative and fails back to UPower whenever raw telemetry is insufficient.