### PR TITLE
Add one-run Bluetooth resume diagnostic capture

### DIFF
--- a/.github/workflows/validate-bluetooth-state.yml
+++ b/.github/workflows/validate-bluetooth-state.yml
@@ -6,16 +6,20 @@ on:
       - main
     paths:
       - config/hypr/scripts/quickshell_bluetooth_state.sh
+      - config/hypr/scripts/quickshell_bluetooth_resume_diagnostic.sh
       - config/quickshell/awtarchy/BluetoothMenu.qml
       - local/share/awtarchy/quickshell-managed-history.sha256
       - tests/test-bluetooth-state-persistence.sh
+      - tests/test-bluetooth-resume-diagnostic.sh
       - .github/workflows/validate-bluetooth-state.yml
   pull_request:
     paths:
       - config/hypr/scripts/quickshell_bluetooth_state.sh
+      - config/hypr/scripts/quickshell_bluetooth_resume_diagnostic.sh
       - config/quickshell/awtarchy/BluetoothMenu.qml
       - local/share/awtarchy/quickshell-managed-history.sha256
       - tests/test-bluetooth-state-persistence.sh
+      - tests/test-bluetooth-resume-diagnostic.sh
       - .github/workflows/validate-bluetooth-state.yml
 
 permissions:
@@ -29,11 +33,23 @@ jobs:
       - name: Bash syntax
         run: |
           bash -n config/hypr/scripts/quickshell_bluetooth_state.sh
+          bash -n config/hypr/scripts/quickshell_bluetooth_resume_diagnostic.sh
           bash -n tests/test-bluetooth-state-persistence.sh
+          bash -n tests/test-bluetooth-resume-diagnostic.sh
       - name: ShellCheck
-        run: shellcheck config/hypr/scripts/quickshell_bluetooth_state.sh tests/test-bluetooth-state-persistence.sh
+        run: |
+          shellcheck \
+            config/hypr/scripts/quickshell_bluetooth_state.sh \
+            tests/test-bluetooth-state-persistence.sh \
+            tests/test-bluetooth-resume-diagnostic.sh
+          # The diagnostic intentionally appends many report fragments and treats
+          # optional command failures as non-fatal evidence gaps. Errors and
+          # warnings remain fatal; ShellCheck info/style findings are not.
+          shellcheck -S warning config/hypr/scripts/quickshell_bluetooth_resume_diagnostic.sh
       - name: Bluetooth persistence and state sync
         run: bash tests/test-bluetooth-state-persistence.sh
+      - name: Bluetooth suspend/resume diagnostic
+        run: bash tests/test-bluetooth-resume-diagnostic.sh
       - name: Managed history
         run: |
           history='local/share/awtarchy/quickshell-managed-history.sha256'

--- a/config/hypr/scripts/quickshell_bluetooth_resume_diagnostic.sh
+++ b/config/hypr/scripts/quickshell_bluetooth_resume_diagnostic.sh
@@ -1,0 +1,522 @@
+#!/usr/bin/env bash
+# Capture one self-contained, read-only Bluetooth suspend/resume diagnostic report.
+
+set -u -o pipefail
+
+CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
+STATE_SCRIPT="${AWTARCHY_BLUETOOTH_STATE_SCRIPT:-${CONFIG_HOME}/hypr/scripts/quickshell_bluetooth_state.sh}"
+RESUME_LOG="${AWTARCHY_BLUETOOTH_RESUME_LOG:-${CACHE_HOME}/awtarchy/quickshell-resume.log}"
+HYPRIDLE_LOG="${AWTARCHY_HYPRIDLE_ACTION_LOG:-${CACHE_HOME}/hypridle/actions.log}"
+BLUETOOTH_CLASS_DIR="${AWTARCHY_BLUETOOTH_CLASS_DIR:-/sys/class/bluetooth}"
+RFKILL_CLASS_DIR="${AWTARCHY_RFKILL_CLASS_DIR:-/sys/class/rfkill}"
+START_DELAY="${AWTARCHY_BLUETOOTH_DIAGNOSTIC_START_DELAY:-2}"
+POST_SECONDS="${AWTARCHY_BLUETOOTH_DIAGNOSTIC_POST_SECONDS:-10}"
+SAMPLE_INTERVAL="${AWTARCHY_BLUETOOTH_DIAGNOSTIC_SAMPLE_INTERVAL:-0.10}"
+DEFAULT_OUTPUT="${CACHE_HOME}/awtarchy/bluetooth-resume-diagnostic-$(date '+%Y%m%d-%H%M%S').txt"
+OUTPUT_FILE="${AWTARCHY_BLUETOOTH_DIAGNOSTIC_OUTPUT:-$DEFAULT_OUTPUT}"
+
+CYCLES=1
+WORK_DIR=""
+RAW_REPORT=""
+FINALIZED=0
+WATCHER_PIDS=()
+
+usage() {
+    printf '%s\n' 'usage: quickshell_bluetooth_resume_diagnostic.sh [--cycles 1-10]' >&2
+    exit 2
+}
+
+is_nonnegative_number() {
+    [[ "$1" =~ ^([0-9]+)(\.[0-9]+)?$ ]]
+}
+
+while (( $# > 0 )); do
+    case "$1" in
+        --cycles)
+            [[ $# -ge 2 ]] || usage
+            CYCLES="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+if [[ ! "$CYCLES" =~ ^[1-9][0-9]*$ ]] || (( CYCLES > 10 )); then
+    printf '%s\n' 'Bluetooth diagnostic cycle count must be between 1 and 10.' >&2
+    exit 2
+fi
+if ! is_nonnegative_number "$START_DELAY"; then
+    printf '%s\n' 'Bluetooth diagnostic start delay must be a non-negative number.' >&2
+    exit 2
+fi
+if ! is_nonnegative_number "$POST_SECONDS"; then
+    printf '%s\n' 'Bluetooth diagnostic post-resume window must be a non-negative number.' >&2
+    exit 2
+fi
+if ! is_nonnegative_number "$SAMPLE_INTERVAL" || [[ "$SAMPLE_INTERVAL" == 0 || "$SAMPLE_INTERVAL" == 0.0 || "$SAMPLE_INTERVAL" == 0.00 ]]; then
+    printf '%s\n' 'Bluetooth diagnostic sample interval must be greater than zero.' >&2
+    exit 2
+fi
+
+command_available() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+state_helper() {
+    local operation="$1"
+    [[ -f "$STATE_SCRIPT" ]] || return 1
+    bash "$STATE_SCRIPT" "$operation"
+}
+
+preflight_disabled() {
+    local saved actual
+
+    if [[ ! -f "$STATE_SCRIPT" ]]; then
+        printf 'Bluetooth state helper is unavailable: %s\n' "$STATE_SCRIPT" >&2
+        return 1
+    fi
+    if ! command_available systemctl; then
+        printf '%s\n' 'systemctl is required for the suspend diagnostic.' >&2
+        return 1
+    fi
+
+    saved="$(state_helper status 2>/dev/null || true)"
+    actual="$(state_helper actual 2>/dev/null || true)"
+
+    if [[ "$saved" != disabled || "$actual" != disabled ]]; then
+        printf '%s\n' 'Bluetooth resume diagnostic was not armed.' >&2
+        printf 'Saved Awtarchy preference: %s\n' "${saved:-unknown}" >&2
+        printf 'Actual BlueZ power state: %s\n' "${actual:-unknown}" >&2
+        printf '%s\n' 'Disable Bluetooth from the Awtarchy flyout, then run the diagnostic again.' >&2
+        return 1
+    fi
+
+    return 0
+}
+
+section() {
+    local title="$1"
+    printf '\n===== %s =====\n' "$title" >>"$RAW_REPORT"
+}
+
+append_command() {
+    local title="$1"
+    shift
+    section "$title"
+    if ! command_available "$1"; then
+        printf 'unavailable command: %s\n' "$1" >>"$RAW_REPORT"
+        return 0
+    fi
+    "$@" >>"$RAW_REPORT" 2>&1 || printf '[command exited %d]\n' "$?" >>"$RAW_REPORT"
+}
+
+append_state_helper() {
+    local title="$1" operation="$2"
+    section "$title"
+    if [[ ! -f "$STATE_SCRIPT" ]]; then
+        printf 'unavailable helper: %s\n' "$STATE_SCRIPT" >>"$RAW_REPORT"
+        return 0
+    fi
+    state_helper "$operation" >>"$RAW_REPORT" 2>&1 || printf '[helper exited %d]\n' "$?" >>"$RAW_REPORT"
+}
+
+line_count() {
+    local file="$1"
+    if [[ -f "$file" ]]; then
+        wc -l <"$file" 2>/dev/null || printf '0\n'
+    else
+        printf '0\n'
+    fi
+}
+
+append_log_delta() {
+    local title="$1" file="$2" previous_lines="$3"
+    local first_new
+
+    section "$title"
+    if [[ ! -r "$file" ]]; then
+        printf 'log unavailable: %s\n' "$file" >>"$RAW_REPORT"
+        return 0
+    fi
+
+    first_new=$((previous_lines + 1))
+    if (( $(line_count "$file") >= first_new )); then
+        tail -n "+${first_new}" "$file" >>"$RAW_REPORT" 2>&1 || true
+    else
+        printf '%s\n' '(no new lines; recent context follows)' >>"$RAW_REPORT"
+        tail -n 80 "$file" >>"$RAW_REPORT" 2>&1 || true
+    fi
+}
+
+append_file() {
+    local title="$1" file="$2"
+    section "$title"
+    if [[ -s "$file" ]]; then
+        cat -- "$file" >>"$RAW_REPORT"
+    else
+        printf '%s\n' '(no events captured)' >>"$RAW_REPORT"
+    fi
+}
+
+capture_sysfs() {
+    local path name value property
+
+    section 'BLUETOOTH/RFKILL SYSFS SNAPSHOT'
+    printf 'bluetooth_class_dir=%s\n' "$BLUETOOTH_CLASS_DIR" >>"$RAW_REPORT"
+    for path in "$BLUETOOTH_CLASS_DIR"/hci*; do
+        [[ -e "$path" ]] || continue
+        name="${path##*/}"
+        printf 'adapter=%s\n' "$name" >>"$RAW_REPORT"
+        printf '  resolved_path=%s\n' "$(readlink -f -- "$path" 2>/dev/null || true)" >>"$RAW_REPORT"
+        printf '  driver=%s\n' "$(readlink -f -- "$path/device/driver" 2>/dev/null || true)" >>"$RAW_REPORT"
+        for property in address name; do
+            if [[ -r "$path/$property" ]]; then
+                value="$(cat -- "$path/$property" 2>/dev/null || true)"
+                printf '  %s=%s\n' "$property" "$value" >>"$RAW_REPORT"
+            fi
+        done
+        for property in power/control power/runtime_status power/runtime_suspended_time power/runtime_active_time; do
+            if [[ -r "$path/device/$property" ]]; then
+                value="$(cat -- "$path/device/$property" 2>/dev/null || true)"
+                printf '  device_%s=%s\n' "${property//\//_}" "$value" >>"$RAW_REPORT"
+            fi
+        done
+    done
+
+    printf 'rfkill_class_dir=%s\n' "$RFKILL_CLASS_DIR" >>"$RAW_REPORT"
+    for path in "$RFKILL_CLASS_DIR"/rfkill*; do
+        [[ -d "$path" ]] || continue
+        [[ -r "$path/type" ]] || continue
+        [[ "$(cat -- "$path/type" 2>/dev/null || true)" == bluetooth ]] || continue
+        printf 'rfkill=%s' "${path##*/}" >>"$RAW_REPORT"
+        for property in name state soft hard; do
+            value="unavailable"
+            [[ -r "$path/$property" ]] && value="$(cat -- "$path/$property" 2>/dev/null || true)"
+            printf ' %s=%s' "$property" "$value" >>"$RAW_REPORT"
+        done
+        printf '\n' >>"$RAW_REPORT"
+    done
+}
+
+capture_snapshot() {
+    local label="$1"
+
+    section "$label"
+    printf 'wall_time=%s\n' "$(date --iso-8601=ns 2>/dev/null || date '+%F %T.%N %z')" >>"$RAW_REPORT"
+    printf 'uptime=%s\n' "$(cut -d' ' -f1 /proc/uptime 2>/dev/null || printf unknown)" >>"$RAW_REPORT"
+    append_state_helper 'SAVED AWTARCHY PREFERENCE' status
+    append_state_helper 'ACTUAL BLUEZ POWER STATE' actual
+    append_command 'BLUETOOTHCTL SHOW' bluetoothctl show
+    append_command 'RFKILL STATE' rfkill list bluetooth
+    capture_sysfs
+    append_command 'BLUETOOTH SERVICE STATUS' systemctl status bluetooth.service --no-pager
+    if command_available busctl; then
+        append_command 'BLUEZ OBJECT TREE' busctl --system tree org.bluez
+    else
+        section 'BLUEZ OBJECT TREE'
+        printf '%s\n' 'busctl unavailable' >>"$RAW_REPORT"
+    fi
+}
+
+adapter_sample_once() {
+    local timestamp path name powered soft hard rf_name
+
+    timestamp="$(date '+%s.%N')"
+    for path in "$BLUETOOTH_CLASS_DIR"/hci*; do
+        [[ -e "$path" ]] || continue
+        name="${path##*/}"
+        powered="unknown"
+        if command_available busctl; then
+            powered="$(timeout 1 busctl --system get-property org.bluez "/org/bluez/${name}" org.bluez.Adapter1 Powered 2>/dev/null | awk '{print $2}' || true)"
+            [[ -n "$powered" ]] || powered="unavailable"
+        fi
+        printf '%s adapter=%s bluez_powered=%s\n' "$timestamp" "$name" "$powered"
+    done
+
+    for path in "$RFKILL_CLASS_DIR"/rfkill*; do
+        [[ -d "$path" && -r "$path/type" ]] || continue
+        [[ "$(cat -- "$path/type" 2>/dev/null || true)" == bluetooth ]] || continue
+        rf_name="$(cat -- "$path/name" 2>/dev/null || printf unknown)"
+        soft="$(cat -- "$path/soft" 2>/dev/null || printf unknown)"
+        hard="$(cat -- "$path/hard" 2>/dev/null || printf unknown)"
+        printf '%s rfkill=%s soft=%s hard=%s\n' "$timestamp" "$rf_name" "$soft" "$hard"
+    done
+}
+
+sample_loop() {
+    while true; do
+        adapter_sample_once
+        sleep "$SAMPLE_INTERVAL"
+    done
+}
+
+start_background() {
+    local output="$1"
+    shift
+
+    if command_available stdbuf; then
+        stdbuf -oL -eL "$@" >"$output" 2>&1 &
+    else
+        "$@" >"$output" 2>&1 &
+    fi
+    WATCHER_PIDS+=("$!")
+}
+
+start_watchers() {
+    local cycle_dir="$1"
+    WATCHER_PIDS=()
+
+    if command_available dbus-monitor; then
+        start_background "$cycle_dir/dbus.log" dbus-monitor --system "type='signal',interface='org.freedesktop.DBus.Properties',member='PropertiesChanged',arg0='org.bluez.Adapter1'"
+    else
+        printf '%s\n' 'dbus-monitor unavailable' >"$cycle_dir/dbus.log"
+    fi
+
+    if command_available rfkill; then
+        start_background "$cycle_dir/rfkill.log" rfkill event
+    else
+        printf '%s\n' 'rfkill unavailable' >"$cycle_dir/rfkill.log"
+    fi
+
+    if command_available udevadm; then
+        start_background "$cycle_dir/udev.log" udevadm monitor --kernel --udev --property --subsystem-match=bluetooth
+    else
+        printf '%s\n' 'udevadm unavailable' >"$cycle_dir/udev.log"
+    fi
+
+    sample_loop >"$cycle_dir/timeline.log" 2>&1 &
+    WATCHER_PIDS+=("$!")
+}
+
+stop_watchers() {
+    local pid
+    for pid in "${WATCHER_PIDS[@]:-}"; do
+        [[ -n "$pid" ]] || continue
+        kill "$pid" 2>/dev/null || true
+    done
+    for pid in "${WATCHER_PIDS[@]:-}"; do
+        [[ -n "$pid" ]] || continue
+        wait "$pid" 2>/dev/null || true
+    done
+    WATCHER_PIDS=()
+}
+
+append_journals() {
+    local since="$1" output
+
+    section 'BLUETOOTH SERVICE JOURNAL'
+    if command_available journalctl; then
+        journalctl -b --since "$since" --no-pager -o short-precise -u bluetooth.service >>"$RAW_REPORT" 2>&1 || true
+    else
+        printf '%s\n' 'journalctl unavailable' >>"$RAW_REPORT"
+    fi
+
+    section 'KERNEL SUSPEND/BLUETOOTH JOURNAL'
+    if command_available journalctl; then
+        output="$(journalctl -b --since "$since" --no-pager -o short-precise 2>&1 || true)"
+        if ! grep -Ei 'bluetooth|bluez|rfkill|btusb|hci[0-9]|suspend|systemd-sleep|PM: ' <<<"$output" >>"$RAW_REPORT"; then
+            printf '%s\n' '(no matching journal lines)' >>"$RAW_REPORT"
+        fi
+    else
+        printf '%s\n' 'journalctl unavailable' >>"$RAW_REPORT"
+    fi
+}
+
+capture_versions() {
+    section 'SYSTEM AND BLUETOOTH VERSIONS'
+    printf 'captured_at=%s\n' "$(date --iso-8601=ns 2>/dev/null || date '+%F %T.%N %z')" >>"$RAW_REPORT"
+    printf 'kernel=%s\n' "$(uname -a 2>/dev/null || printf unknown)" >>"$RAW_REPORT"
+    printf 'state_helper=%s\n' "$STATE_SCRIPT" >>"$RAW_REPORT"
+    if command_available sha256sum && [[ -f "$STATE_SCRIPT" ]]; then
+        sha256sum "$STATE_SCRIPT" >>"$RAW_REPORT" 2>&1 || true
+    fi
+    command_available bluetoothctl && bluetoothctl --version >>"$RAW_REPORT" 2>&1 || true
+    command_available rfkill && rfkill --version >>"$RAW_REPORT" 2>&1 || true
+    command_available systemctl && systemctl --version >>"$RAW_REPORT" 2>&1 || true
+    command_available pacman && pacman -Q bluez bluez-utils >>"$RAW_REPORT" 2>&1 || true
+    command_available loginctl && loginctl session-status >>"$RAW_REPORT" 2>&1 || true
+
+    printf '\n-- USB devices --\n' >>"$RAW_REPORT"
+    command_available lsusb && lsusb >>"$RAW_REPORT" 2>&1 || printf '%s\n' 'lsusb unavailable' >>"$RAW_REPORT"
+    printf '\n-- PCI network/wireless devices --\n' >>"$RAW_REPORT"
+    if command_available lspci; then
+        lspci 2>&1 | grep -Ei 'network|wireless|bluetooth' >>"$RAW_REPORT" || printf '%s\n' '(no matching PCI lines)' >>"$RAW_REPORT"
+    else
+        printf '%s\n' 'lspci unavailable' >>"$RAW_REPORT"
+    fi
+}
+
+dbus_powered_true_observed() {
+    local file="$1"
+    [[ -s "$file" ]] || return 1
+
+    awk '
+        /^[[:space:]]*string "Powered"[[:space:]]*$/ {
+            waiting_for_powered_value = 1
+            next
+        }
+        waiting_for_powered_value && /boolean true/ {
+            found = 1
+            exit
+        }
+        waiting_for_powered_value && /boolean false/ {
+            waiting_for_powered_value = 0
+            next
+        }
+        waiting_for_powered_value && /^[[:space:]]*string "/ {
+            waiting_for_powered_value = 0
+        }
+        END {
+            exit(found ? 0 : 1)
+        }
+    ' "$file"
+}
+
+append_cycle_observation() {
+    local cycle_dir="$1" saved actual transient=no
+
+    saved="$(state_helper status 2>/dev/null || true)"
+    actual="$(state_helper actual 2>/dev/null || true)"
+    if grep -Fq 'bluez_powered=true' "$cycle_dir/timeline.log" 2>/dev/null \
+        || dbus_powered_true_observed "$cycle_dir/dbus.log"; then
+        transient=yes
+    fi
+
+    section 'AUTOMATIC OBSERVATION'
+    printf 'post_saved=%s\n' "${saved:-unknown}" >>"$RAW_REPORT"
+    printf 'post_actual=%s\n' "${actual:-unknown}" >>"$RAW_REPORT"
+    printf 'adapter_powered_true_observed=%s\n' "$transient" >>"$RAW_REPORT"
+
+    if [[ "$saved" == enabled && "$actual" == enabled ]]; then
+        printf '%s\n' 'classification=persisted preference changed to enabled or was rewritten during resume' >>"$RAW_REPORT"
+    elif [[ "$saved" == disabled && "$actual" == enabled ]]; then
+        printf '%s\n' 'classification=resume restore failed or lost a race; final actual state is enabled' >>"$RAW_REPORT"
+    elif [[ "$saved" == disabled && "$actual" == disabled && "$transient" == yes ]]; then
+        printf '%s\n' 'classification=transient adapter-powered-on event observed before final disabled state' >>"$RAW_REPORT"
+    elif [[ "$saved" == disabled && "$actual" == disabled ]]; then
+        printf '%s\n' 'classification=no powered-on event observed in this cycle' >>"$RAW_REPORT"
+    else
+        printf '%s\n' 'classification=state became indeterminate; inspect raw evidence' >>"$RAW_REPORT"
+    fi
+
+    [[ "$saved" == disabled && "$actual" == disabled ]]
+}
+
+sanitize_report() {
+    sed -E \
+        -e 's/([[:xdigit:]]{2}:){5}[[:xdigit:]]{2}/<MAC>/g' \
+        -e 's/(dev_)?([[:xdigit:]]{2}_){5}[[:xdigit:]]{2}/<MAC_PATH>/g' \
+        "$RAW_REPORT"
+}
+
+finalize_report() {
+    local output_dir output_tmp
+    (( FINALIZED == 0 )) || return 0
+    [[ -n "$RAW_REPORT" && -f "$RAW_REPORT" ]] || return 0
+
+    output_dir="$(dirname -- "$OUTPUT_FILE")"
+    mkdir -p -- "$output_dir"
+    output_tmp="${OUTPUT_FILE}.tmp.$$"
+    sanitize_report >"$output_tmp"
+    chmod 0600 -- "$output_tmp" 2>/dev/null || true
+    mv -f -- "$output_tmp" "$OUTPUT_FILE"
+    FINALIZED=1
+}
+
+cleanup() {
+    stop_watchers
+    finalize_report || true
+    [[ -n "$WORK_DIR" ]] && rm -rf -- "$WORK_DIR"
+}
+trap cleanup EXIT
+trap 'exit 130' INT TERM
+
+preflight_disabled || exit 1
+
+WORK_DIR="$(mktemp -d)"
+RAW_REPORT="$WORK_DIR/report.raw"
+printf '%s\n' 'Awtarchy Bluetooth Suspend/Resume Diagnostic' >"$RAW_REPORT"
+printf 'requested_cycles=%d\n' "$CYCLES" >>"$RAW_REPORT"
+printf 'start_delay_seconds=%s\n' "$START_DELAY" >>"$RAW_REPORT"
+printf 'post_resume_capture_seconds=%s\n' "$POST_SECONDS" >>"$RAW_REPORT"
+printf 'sample_interval_seconds=%s\n' "$SAMPLE_INTERVAL" >>"$RAW_REPORT"
+printf 'output=%s\n' "$OUTPUT_FILE" >>"$RAW_REPORT"
+capture_versions
+
+printf 'Bluetooth resume diagnostic armed for %d cycle(s).\n' "$CYCLES"
+printf '%s\n' 'Bluetooth state will only be observed; the diagnostic does not toggle it.'
+
+for ((cycle = 1; cycle <= CYCLES; cycle++)); do
+    cycle_dir="$WORK_DIR/cycle-${cycle}"
+    mkdir -p -- "$cycle_dir"
+
+    if ! preflight_disabled; then
+        section "CYCLE ${cycle} ABORTED BEFORE SUSPEND"
+        printf '%s\n' 'Bluetooth was not disabled at cycle preflight; no additional suspend was attempted.' >>"$RAW_REPORT"
+        break
+    fi
+
+    resume_lines="$(line_count "$RESUME_LOG")"
+    hypridle_lines="$(line_count "$HYPRIDLE_LOG")"
+    cycle_since="$(date --iso-8601=seconds 2>/dev/null || date '+%F %T')"
+
+    capture_snapshot "CYCLE ${cycle} PRE-SUSPEND"
+    start_watchers "$cycle_dir"
+
+    if [[ "$START_DELAY" != 0 ]]; then
+        printf 'Cycle %d/%d: capturing baseline for %s second(s), then suspending.\n' "$cycle" "$CYCLES" "$START_DELAY"
+        sleep "$START_DELAY"
+    else
+        printf 'Cycle %d/%d: suspending now.\n' "$cycle" "$CYCLES"
+    fi
+
+    section "CYCLE ${cycle} SUSPEND BOUNDARY"
+    printf 'suspend_requested_wall=%s\n' "$(date --iso-8601=ns 2>/dev/null || date '+%F %T.%N %z')" >>"$RAW_REPORT"
+    printf 'suspend_requested_uptime=%s\n' "$(cut -d' ' -f1 /proc/uptime 2>/dev/null || printf unknown)" >>"$RAW_REPORT"
+
+    if ! systemctl suspend; then
+        printf '%s\n' 'systemctl suspend failed; stopping diagnostic.' >&2
+        printf '%s\n' 'systemctl_suspend_result=failed' >>"$RAW_REPORT"
+        stop_watchers
+        break
+    fi
+
+    printf 'suspend_returned_wall=%s\n' "$(date --iso-8601=ns 2>/dev/null || date '+%F %T.%N %z')" >>"$RAW_REPORT"
+    printf 'suspend_returned_uptime=%s\n' "$(cut -d' ' -f1 /proc/uptime 2>/dev/null || printf unknown)" >>"$RAW_REPORT"
+
+    if [[ "$POST_SECONDS" != 0 ]]; then
+        printf 'Cycle %d/%d: awake; capturing the resume window for %s second(s).\n' "$cycle" "$CYCLES" "$POST_SECONDS"
+        sleep "$POST_SECONDS"
+    fi
+
+    stop_watchers
+    capture_snapshot "CYCLE ${cycle} POST-RESUME"
+    append_file 'HIGH-RESOLUTION ADAPTER TIMELINE' "$cycle_dir/timeline.log"
+    append_file 'BLUEZ ADAPTER DBUS EVENTS' "$cycle_dir/dbus.log"
+    append_file 'RFKILL EVENTS' "$cycle_dir/rfkill.log"
+    append_file 'UDEV BLUETOOTH EVENTS' "$cycle_dir/udev.log"
+    append_log_delta 'AWTARCHY RESUME RECOVERY LOG' "$RESUME_LOG" "$resume_lines"
+    append_log_delta 'HYPRIDLE ACTION LOG' "$HYPRIDLE_LOG" "$hypridle_lines"
+    append_journals "$cycle_since"
+
+    if ! append_cycle_observation "$cycle_dir"; then
+        printf '%s\n' 'Bluetooth no longer finished disabled; stopping additional cycles to preserve the evidence.'
+        break
+    fi
+
+    if (( cycle < CYCLES )) && [[ -t 0 ]]; then
+        printf 'Cycle %d complete. Press Enter when ready for the next suspend, or Ctrl+C to finish with the current report.\n' "$cycle"
+        IFS= read -r _ || true
+    fi
+done
+
+section 'DIAGNOSTIC COMPLETE'
+printf 'completed_at=%s\n' "$(date --iso-8601=ns 2>/dev/null || date '+%F %T.%N %z')" >>"$RAW_REPORT"
+finalize_report
+printf 'Bluetooth resume diagnostic report: %s\n' "$OUTPUT_FILE"

--- a/local/share/awtarchy/quickshell-managed-history.sha256
+++ b/local/share/awtarchy/quickshell-managed-history.sha256
@@ -866,3 +866,6 @@ ab73a9056ecd3cd692112cf218464c9abe1de5792b0fdaad1f6401b063a0d967	.config/hypr/sc
 # 2026-09-05 phantom battery telemetry correction.
 47e867d2068784aa6850deb4c9e9c014f24110458378534724dc00546040a86c	.config/hypr/scripts/quickshell_battery_telemetry.sh
 e510b4b5ec3262870d7c9a9551e5a9e07fd30ae93416818b8578270aa42a31a0	.config/quickshell/awtarchy/BatteryState.qml
+
+# 2026-09-06 Bluetooth resume diagnostic capture.
+f9a373581ddb471d5bdafe26abdd9cf07ad7a2d1cc8a2177cb8d69d0ed31be72	.config/hypr/scripts/quickshell_bluetooth_resume_diagnostic.sh

--- a/tests/test-bluetooth-resume-diagnostic.sh
+++ b/tests/test-bluetooth-resume-diagnostic.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+DIAGNOSTIC="${ROOT}/config/hypr/scripts/quickshell_bluetooth_resume_diagnostic.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf -- "$tmp"' EXIT
+
+[[ -f "$DIAGNOSTIC" ]] || {
+    printf '%s\n' 'Bluetooth resume diagnostic script is missing.' >&2
+    exit 1
+}
+
+mkdir -p "$tmp/bin" "$tmp/out" "$tmp/cache/awtarchy" "$tmp/cache/hypridle" "$tmp/bluetooth/hci0" "$tmp/rfkill/rfkill0"
+printf '%s\n' '0' >"$tmp/rfkill/rfkill0/soft"
+printf '%s\n' '0' >"$tmp/rfkill/rfkill0/hard"
+printf '%s\n' '1' >"$tmp/rfkill/rfkill0/state"
+printf '%s\n' 'bluetooth' >"$tmp/rfkill/rfkill0/type"
+printf '%s\n' 'hci0' >"$tmp/rfkill/rfkill0/name"
+printf '%s\n' 'old resume line' >"$tmp/cache/awtarchy/quickshell-resume.log"
+printf '%s\n' 'old hypridle line' >"$tmp/cache/hypridle/actions.log"
+
+cat >"$tmp/bluetooth-state-helper" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${HELPER_LOG:?}"
+case "${1:-}" in
+    status) printf '%s\n' "${FAKE_SAVED_STATE:-disabled}" ;;
+    actual) printf '%s\n' "${FAKE_ACTUAL_STATE:-disabled}" ;;
+    *) exit 88 ;;
+esac
+FAKE
+
+cat >"$tmp/bin/systemctl" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${SYSTEMCTL_LOG:?}"
+case "${1:-}" in
+    suspend) exit 0 ;;
+    status) printf '%s\n' 'bluetooth.service active (running)' ;;
+    show) printf '%s\n' 'ActiveState=active' 'SubState=running' ;;
+    *) exit 0 ;;
+esac
+FAKE
+
+cat >"$tmp/bin/bluetoothctl" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+    show)
+        printf '%s\n' 'Controller AA:BB:CC:DD:EE:FF Test Adapter' '    Powered: no' '    Discovering: no'
+        ;;
+    --version|-v)
+        printf '%s\n' 'bluetoothctl: 5.test'
+        ;;
+    *)
+        printf '%s\n' 'bluetoothctl fake output'
+        ;;
+esac
+FAKE
+
+cat >"$tmp/bin/rfkill" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == event ]]; then
+    printf '%s\n' '2026-09-05 20:00:00 rfkill event bluetooth soft=0 hard=0'
+    sleep 5
+else
+    printf '%s\n' '0: hci0: Bluetooth' '    Soft blocked: no' '    Hard blocked: no'
+fi
+FAKE
+
+cat >"$tmp/bin/dbus-monitor" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' \
+    "signal time=1.000 sender=:1.9 path=/org/bluez/hci0; interface=org.freedesktop.DBus.Properties; member=PropertiesChanged" \
+    '   string "org.bluez.Adapter1"' \
+    '   string "Powered"' \
+    '   boolean false' \
+    "signal time=1.100 sender=:1.9 path=/org/bluez/hci0; interface=org.freedesktop.DBus.Properties; member=PropertiesChanged" \
+    '   string "org.bluez.Adapter1"' \
+    '   string "Discoverable"' \
+    '   boolean true'
+sleep 5
+FAKE
+
+cat >"$tmp/bin/udevadm" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == monitor ]]; then
+    printf '%s\n' 'UDEV [1.000] change /devices/test/bluetooth/hci0 (bluetooth)'
+    sleep 5
+else
+    printf '%s\n' 'udevadm fake output'
+fi
+FAKE
+
+cat >"$tmp/bin/busctl" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$*" == *'get-property'* ]]; then
+    printf '%s\n' 'b false'
+elif [[ "$*" == *'tree'* ]]; then
+    printf '%s\n' '`-/org/bluez/hci0'
+else
+    printf '%s\n' 'busctl fake output'
+fi
+FAKE
+
+cat >"$tmp/bin/journalctl" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' 'Sep 05 20:00:01 host bluetoothd[100]: Adapter AA:BB:CC:DD:EE:FF resumed' 'Sep 05 20:00:01 host kernel: Bluetooth: hci0 resumed'
+FAKE
+
+cat >"$tmp/bin/loginctl" <<'FAKE'
+#!/usr/bin/env bash
+printf '%s\n' 'session-status fake'
+FAKE
+
+cat >"$tmp/bin/lsusb" <<'FAKE'
+#!/usr/bin/env bash
+printf '%s\n' 'Bus 001 Device 001: ID 1234:5678 Bluetooth Adapter'
+FAKE
+
+cat >"$tmp/bin/lspci" <<'FAKE'
+#!/usr/bin/env bash
+printf '%s\n' '00:14.0 Network controller: Test Bluetooth companion'
+FAKE
+
+cat >"$tmp/bin/pacman" <<'FAKE'
+#!/usr/bin/env bash
+printf '%s\n' 'bluez 5.test' 'bluez-utils 5.test'
+FAKE
+
+chmod 0755 "$tmp/bluetooth-state-helper" "$tmp/bin/"*
+
+export PATH="$tmp/bin:$PATH"
+export HELPER_LOG="$tmp/helper.log"
+export SYSTEMCTL_LOG="$tmp/systemctl.log"
+export XDG_CACHE_HOME="$tmp/cache"
+
+# The diagnostic must refuse to start a suspend cycle unless both the saved
+# Awtarchy preference and the actual BlueZ state are already disabled.
+: >"$SYSTEMCTL_LOG"
+FAKE_SAVED_STATE=enabled \
+FAKE_ACTUAL_STATE=disabled \
+AWTARCHY_BLUETOOTH_STATE_SCRIPT="$tmp/bluetooth-state-helper" \
+AWTARCHY_BLUETOOTH_DIAGNOSTIC_OUTPUT="$tmp/out/refused.txt" \
+AWTARCHY_BLUETOOTH_CLASS_DIR="$tmp/bluetooth" \
+AWTARCHY_RFKILL_CLASS_DIR="$tmp/rfkill" \
+AWTARCHY_BLUETOOTH_DIAGNOSTIC_START_DELAY=0.2 \
+AWTARCHY_BLUETOOTH_DIAGNOSTIC_POST_SECONDS=0 \
+AWTARCHY_BLUETOOTH_DIAGNOSTIC_SAMPLE_INTERVAL=0.01 \
+    bash "$DIAGNOSTIC" --cycles 1 >/dev/null 2>&1 && {
+        printf '%s\n' 'Diagnostic suspended even though saved Bluetooth preference was enabled.' >&2
+        exit 1
+    }
+if grep -Fxq 'suspend' "$SYSTEMCTL_LOG"; then
+    printf '%s\n' 'Diagnostic called systemctl suspend after failing its preflight.' >&2
+    exit 1
+fi
+
+# A successful run may perform multiple suspend/resume cycles while remaining
+# read-only with respect to Bluetooth state. It emits one sanitized report.
+: >"$HELPER_LOG"
+: >"$SYSTEMCTL_LOG"
+rm -f -- "$tmp/out/"*
+report="$tmp/out/report.txt"
+FAKE_SAVED_STATE=disabled \
+FAKE_ACTUAL_STATE=disabled \
+AWTARCHY_BLUETOOTH_STATE_SCRIPT="$tmp/bluetooth-state-helper" \
+AWTARCHY_BLUETOOTH_DIAGNOSTIC_OUTPUT="$report" \
+AWTARCHY_BLUETOOTH_CLASS_DIR="$tmp/bluetooth" \
+AWTARCHY_RFKILL_CLASS_DIR="$tmp/rfkill" \
+AWTARCHY_BLUETOOTH_RESUME_LOG="$tmp/cache/awtarchy/quickshell-resume.log" \
+AWTARCHY_HYPRIDLE_ACTION_LOG="$tmp/cache/hypridle/actions.log" \
+AWTARCHY_BLUETOOTH_DIAGNOSTIC_START_DELAY=0.2 \
+AWTARCHY_BLUETOOTH_DIAGNOSTIC_POST_SECONDS=0 \
+AWTARCHY_BLUETOOTH_DIAGNOSTIC_SAMPLE_INTERVAL=0.01 \
+    bash "$DIAGNOSTIC" --cycles 2 >/dev/null
+
+[[ -s "$report" ]]
+[[ "$(grep -Fxc 'suspend' "$SYSTEMCTL_LOG")" -eq 2 ]]
+[[ "$(find "$tmp/out" -maxdepth 1 -type f | wc -l)" -eq 1 ]]
+
+for marker in \
+    'Awtarchy Bluetooth Suspend/Resume Diagnostic' \
+    'CYCLE 1 PRE-SUSPEND' \
+    'CYCLE 1 POST-RESUME' \
+    'CYCLE 2 PRE-SUSPEND' \
+    'CYCLE 2 POST-RESUME' \
+    'SAVED AWTARCHY PREFERENCE' \
+    'ACTUAL BLUEZ POWER STATE' \
+    'BLUETOOTHCTL SHOW' \
+    'RFKILL STATE' \
+    'HIGH-RESOLUTION ADAPTER TIMELINE' \
+    'BLUEZ ADAPTER DBUS EVENTS' \
+    'RFKILL EVENTS' \
+    'UDEV BLUETOOTH EVENTS' \
+    'AWTARCHY RESUME RECOVERY LOG' \
+    'HYPRIDLE ACTION LOG' \
+    'BLUETOOTH SERVICE JOURNAL' \
+    'KERNEL SUSPEND/BLUETOOTH JOURNAL' \
+    'SYSTEM AND BLUETOOTH VERSIONS'
+do
+    grep -Fq "$marker" "$report" || {
+        printf 'Diagnostic report is missing section: %s\n' "$marker" >&2
+        exit 1
+    }
+done
+
+grep -Fq 'disabled' "$report"
+grep -Fq '<MAC>' "$report"
+if grep -Fq 'AA:BB:CC:DD:EE:FF' "$report"; then
+    printf '%s\n' 'Diagnostic report leaked an unsanitized Bluetooth MAC address.' >&2
+    exit 1
+fi
+if grep -Fq 'adapter_powered_true_observed=yes' "$report"; then
+    printf '%s\n' 'Diagnostic misclassified an unrelated Adapter1 boolean=true event as Bluetooth Powered=true.' >&2
+    exit 1
+fi
+grep -Fq 'classification=no powered-on event observed in this cycle' "$report"
+if grep -Eq '^(restore|set)([[:space:]]|$)' "$HELPER_LOG"; then
+    printf '%s\n' 'Diagnostic changed Bluetooth state instead of remaining observational.' >&2
+    exit 1
+fi
+
+grep -Fxq 'status' "$HELPER_LOG"
+grep -Fxq 'actual' "$HELPER_LOG"
+
+printf '%s\n' 'Bluetooth suspend/resume diagnostic regression test: PASS'


### PR DESCRIPTION
## Purpose

Add a diagnostics-only suspend/resume capture for issue #146 so one real reproduction produces one self-contained report instead of requiring repeated manual terminal output.

This PR does not change Bluetooth restore behavior.

## Behavior

- Requires both the saved Awtarchy preference and actual BlueZ power state to be disabled before suspending.
- Passively captures BlueZ D-Bus property changes, high-resolution Adapter1 power samples, rfkill/udev events, sysfs state, resume/hypridle logs, and relevant BlueZ/kernel journals.
- Sanitizes Bluetooth MAC addresses in the final report.
- Supports multiple suspend/resume cycles and stops additional cycles if Bluetooth no longer finishes disabled.
- Calls the Bluetooth state helper only for `status` and `actual`; it never calls `set` or `restore`.

## TDD evidence

A deterministic regression fixture proved that an unrelated `Adapter1` boolean property such as `Discoverable=true` must not be classified as `Powered=true`. The test failed on the over-broad parser and passes with the property-specific parser.

## Validation

Exact final head `b8c34e0ca676c8d72922fb521c6610c5ab842be4` passed:

- Bash syntax
- ShellCheck
- Existing Bluetooth persistence/state-sync regression
- New suspend/resume diagnostic regression
- Managed-history/updater migration validation
- Full PR workflow set: 18/18 successful

No real-hardware conclusion is claimed here; this PR only improves evidence capture for the later reproduction.

Refs #146.