### PR TITLE
Release notes bridge: restore v3.5.6 Getting started

### DIFF
--- a/.github/release-v3.5.6-updated.md
+++ b/.github/release-v3.5.6-updated.md
@@ -1,0 +1,97 @@
+# Awtarchy v3.5.6 Quickshell
+
+Awtarchy v3.5.6 is primarily an architectural correction to Battery Care. It deliberately backs away from the large Awtarchy-maintained TLP vendor/plugin compatibility layer introduced in v3.5.5 and returns hardware compatibility ownership to TLP, where it belongs.
+
+## Getting started
+
+Awtarchy is an Arch Linux overlay/environment, not a Linux distribution or an Arch Linux installer. Install it onto a working minimal Arch Linux system.
+
+If you are starting from zero:
+
+1. Download the official Arch Linux ISO from the [Arch Linux download page](https://archlinux.org/download/).
+2. Boot the Arch Linux ISO.
+3. Install a working minimal Arch Linux system first.
+   - For most users, Awtarchy recommends the official `archinstall` guided installer included with the Arch ISO as the easiest path. Run `archinstall` from the live environment and complete a minimal Arch installation.
+   - A normal manual Arch installation using the [ArchWiki Installation Guide](https://wiki.archlinux.org/title/Installation_guide) is also fine.
+4. Boot into the installed Arch system.
+
+Once you have a working minimal Arch installation, install Awtarchy:
+
+```bash
+sudo pacman -S git --noconfirm
+git clone https://github.com/dillacorn/awtarchy
+cd awtarchy
+sudo ./awtarchy-install.sh
+```
+
+## Existing Awtarchy users
+
+```bash
+awtarchy update
+```
+
+## Why Battery Care is changing again
+
+v3.5.5 expanded Awtarchy's own Battery Care backend logic to understand current TLP vendor plugins, firmware-specific OFF values, selector modes, readback quirks, multi-battery translations, and other hardware behavior.
+
+That worked, but it also made Awtarchy a second battery-hardware policy engine beside TLP. Every new laptop quirk or TLP plugin change could then require another Awtarchy compatibility update. That is unnecessary maintenance and increases the chance that Awtarchy and upstream TLP disagree about the same hardware.
+
+v3.5.6 intentionally backpedals on that design.
+
+- **TLP remains the battery hardware backend and compatibility authority.** TLP owns vendor/plugin detection, valid threshold values, hardware quirks, validation, and writes.
+- **Awtarchy's Quickshell Battery Care UI remains.** It is now a thin generic client for numeric charge-threshold controls that TLP explicitly advertises.
+- **TLPUI is installed as the advanced sibling UI**, not imported as an Awtarchy backend or library. Hardware-specific selector/advanced modes that do not map cleanly to generic percentages are left to TLP/TLPUI instead of being reimplemented in Awtarchy.
+- Awtarchy persists only standard TLP threshold settings in its owned `/etc/tlp.d/00-awtarchy-battery-care.conf` drop-in and asks TLP to apply them with `tlp setcharge`.
+- The old special AUR path for `tlpui` is gone. `tlp`, `tlp-pd`, and `tlpui` are installed through Arch's normal repository package path after the `power-profiles-daemon` conflict is resolved.
+
+This keeps the polished Quickshell controls while removing hardware compatibility administration that upstream TLP is already designed to own.
+
+## Battery Care behavior
+
+- Generic TLP-advertised numeric ranges and percentage presets remain writable from Quickshell without checking a vendor/plugin allowlist.
+- Future TLP plugins exposing the same generic percentage interface can work without an Awtarchy vendor-specific code change.
+- TLP `charge type` and other selector-style modes remain read-only in Awtarchy and can be managed through TLPUI.
+- Stop-only interfaces use TLP's generic semantics, including `START_CHARGE_THRESH=0` where no usable start control is advertised.
+- Standard TLP configuration suffixes are derived from TLP's advertised parameter names rather than guessed from vendor identity or physical battery names.
+- External user/TLPUI threshold configuration still fails closed instead of being silently overwritten.
+- Multi-battery handling remains conservative, and full-charge recovery attempts every TLP-reported physical battery.
+- All Battery Care hardware writes go through TLP; Awtarchy no longer writes vendor-specific battery sysfs controls directly or tries to second-guess successful TLP writes with its own firmware-specific verifier.
+
+## Real-hardware fixes found during testing
+
+Two issues were found only after testing the refactor on real Arch/Sony hardware and were fixed before release.
+
+### Protected sudoers directories
+
+Awtarchy's read-only `tlp-stat -b` helper policy was valid, but the post-install verifier tried to inspect `/etc/sudoers.d/awtarchy-battery-status-*` as the desktop user. On a correctly protected root-owned `0750` `/etc/sudoers.d`, that user cannot traverse the directory, so installation falsely failed.
+
+Policy-file inspection now uses the existing root boundary while retaining the owner, mode, symlink, marker, and `visudo` safety checks. The existing-policy guard is root-aware too, so a foreign policy cannot be hidden by directory permissions and accidentally replaced.
+
+### Stop-only TLP logical readback
+
+Some hardware exposes its logical applied threshold in TLP's Battery Care report without a standard `power_supply` stop-threshold file. Awtarchy previously showed `Unknown` or a generic `On` state in that case.
+
+The detector can now consume TLP's normalized logical percentage from the generic Battery Care report, but only when the value matches TLP's advertised range/presets. It does not interpret the vendor path or raw hardware encoding.
+
+Real Sony hardware with TLP 1.10.2 was validated at both ends:
+
+- full charging restored -> Awtarchy normalized `target=100`, `enabled=false`;
+- 80% selected -> TLP reported `80%`, the managed drop-in used `START_CHARGE_THRESH_BAT0=0` and `STOP_CHARGE_THRESH_BAT0=80`, and Awtarchy normalized `target=80`, `enabled=true`.
+
+## Other maintenance included since v3.5.5
+
+- Battery telemetry was centralized and hardened to avoid treating dead/phantom battery reports as real usable packs without sufficient evidence.
+- Clipboard thumbnail rendering keeps the v3.5.5 post-release resource hardening: first-frame rendering, bounded ImageMagick resources, and timeout protection.
+- A one-run Bluetooth suspend/resume diagnostic collector is included for issue #146. It is observational only; v3.5.6 does **not** claim to fix the intermittent Bluetooth resume behavior because the real failure has not reproduced reliably enough to justify a behavioral patch.
+
+## Validation
+
+- Exact release target: `1295e13b9323463b735f1793e5251ca4a2529eef`.
+- PR #156 passed all 22 pull-request workflows on exact reviewed head `00db570a85a5616a4309c398d7e06dee9228da85`.
+- The final Battery Care states were validated on real Sony hardware before merge.
+- All 10 push workflows for the exact merged release target completed successfully. `Validate Awtarchy` passed Bash syntax, ShellCheck, desktop-entry validation, and the complete command/updater integration suite on its verification rerun.
+- Battery Care CI covers generic future plugins, numeric ranges/presets, selector rejection, stop-only readback, protected sudoers policy handling, write rollback, multi-battery behavior, TLPUI package integration, managed-history migration, and the absence of Awtarchy vendor-specific write policy.
+
+## Post-release updates
+
+_Placeholder for possible tested post-release patches to v3.5.6._

--- a/.github/workflows/validate-bluetooth-state.yml
+++ b/.github/workflows/validate-bluetooth-state.yml
@@ -67,7 +67,7 @@ jobs:
           done
           (( missing == 0 ))
 
-  repair-v3-5-6-release-notes:
+  cleanup-v3-5-6-notes-bridge:
     if: >-
       github.event_name == 'pull_request' &&
       github.event.pull_request.number == 158 &&
@@ -78,13 +78,7 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout exact release notes bridge
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-        with:
-          ref: release/v3.5.6-notes-bridge
-          fetch-depth: 0
-
-      - name: Restore Getting started section without moving release
+      - name: Verify corrected release and delete helper branch
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -95,17 +89,24 @@ jobs:
           current_main="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" --jq '.object.sha')"
           test "$current_main" = "$EXPECTED_SHA"
 
-          release_name="$(gh release view v3.5.6 --repo "$GITHUB_REPOSITORY" --json name --jq '.name')"
-          release_tag="$(gh release view v3.5.6 --repo "$GITHUB_REPOSITORY" --json tagName --jq '.tagName')"
-          release_draft="$(gh release view v3.5.6 --repo "$GITHUB_REPOSITORY" --json isDraft --jq '.isDraft')"
-          release_prerelease="$(gh release view v3.5.6 --repo "$GITHUB_REPOSITORY" --json isPrerelease --jq '.isPrerelease')"
-          release_target="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/v3.5.6" --jq '.target_commitish')"
+          test "$(gh release view v3.5.6 --repo "$GITHUB_REPOSITORY" --json name --jq '.name')" = 'Awtarchy v3.5.6 Quickshell'
+          test "$(gh release view v3.5.6 --repo "$GITHUB_REPOSITORY" --json tagName --jq '.tagName')" = 'v3.5.6'
+          test "$(gh release view v3.5.6 --repo "$GITHUB_REPOSITORY" --json isDraft --jq '.isDraft')" = 'false'
+          test "$(gh release view v3.5.6 --repo "$GITHUB_REPOSITORY" --json isPrerelease --jq '.isPrerelease')" = 'false'
+          test "$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/v3.5.6" --jq '.target_commitish')" = "$EXPECTED_SHA"
 
-          test "$release_name" = 'Awtarchy v3.5.6 Quickshell'
-          test "$release_tag" = 'v3.5.6'
-          test "$release_draft" = 'false'
-          test "$release_prerelease" = 'false'
-          test "$release_target" = "$EXPECTED_SHA"
+          gh release view v3.5.6 --repo "$GITHUB_REPOSITORY" --json body --jq '.body' > /tmp/v3.5.6-published.md
+          grep -Fq '## Getting started' /tmp/v3.5.6-published.md
+          grep -Fq 'https://archlinux.org/download/' /tmp/v3.5.6-published.md
+          grep -Fq 'https://wiki.archlinux.org/title/Installation_guide' /tmp/v3.5.6-published.md
+          grep -Fq 'sudo pacman -S git --noconfirm' /tmp/v3.5.6-published.md
+          grep -Fq 'git clone https://github.com/dillacorn/awtarchy' /tmp/v3.5.6-published.md
+          grep -Fq 'sudo ./awtarchy-install.sh' /tmp/v3.5.6-published.md
+          grep -Fq '## Existing Awtarchy users' /tmp/v3.5.6-published.md
+          grep -Fq 'awtarchy update' /tmp/v3.5.6-published.md
+          grep -Fq '## Why Battery Care is changing again' /tmp/v3.5.6-published.md
+          grep -Fq '## Validation' /tmp/v3.5.6-published.md
+          grep -Fq '_Placeholder for possible tested post-release patches to v3.5.6._' /tmp/v3.5.6-published.md
 
           tag_type="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/v3.5.6" --jq '.object.type')"
           tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/v3.5.6" --jq '.object.sha')"
@@ -113,65 +114,5 @@ jobs:
             tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${tag_sha}" --jq '.object.sha')"
           fi
           test "$tag_sha" = "$EXPECTED_SHA"
-
-          gh release view v3.5.6 --repo "$GITHUB_REPOSITORY" --json body --jq '.body' > /tmp/v3.5.6-current.md
-          ! grep -Fq '## Getting started' /tmp/v3.5.6-current.md
-          grep -Fq '## Existing Awtarchy users' /tmp/v3.5.6-current.md
-
-          python3 - <<'PY'
-          from pathlib import Path
-
-          path = Path('/tmp/v3.5.6-current.md')
-          body = path.read_text()
-          marker = '## Existing Awtarchy users\n'
-          section = (
-              '## Getting started\n\n'
-              'Awtarchy is an Arch Linux overlay/environment, not a Linux distribution or an Arch Linux installer. Install it onto a working minimal Arch Linux system.\n\n'
-              'If you are starting from zero:\n\n'
-              '1. Download the official Arch Linux ISO from the [Arch Linux download page](https://archlinux.org/download/).\n'
-              '2. Boot the Arch Linux ISO.\n'
-              '3. Install a working minimal Arch Linux system first.\n'
-              '   - For most users, Awtarchy recommends the official `archinstall` guided installer included with the Arch ISO as the easiest path. Run `archinstall` from the live environment and complete a minimal Arch installation.\n'
-              '   - A normal manual Arch installation using the [ArchWiki Installation Guide](https://wiki.archlinux.org/title/Installation_guide) is also fine.\n'
-              '4. Boot into the installed Arch system.\n\n'
-              'Once you have a working minimal Arch installation, install Awtarchy:\n\n'
-              '```bash\n'
-              'sudo pacman -S git --noconfirm\n'
-              'git clone https://github.com/dillacorn/awtarchy\n'
-              'cd awtarchy\n'
-              'sudo ./awtarchy-install.sh\n'
-              '```\n\n'
-          )
-          if body.count(marker) != 1:
-              raise SystemExit('Expected exactly one Existing Awtarchy users heading')
-          updated = body.replace(marker, section + marker, 1)
-          Path('/tmp/v3.5.6-updated.md').write_text(updated)
-          PY
-
-          gh release edit v3.5.6 --repo "$GITHUB_REPOSITORY" --notes-file /tmp/v3.5.6-updated.md
-
-          gh release view v3.5.6 --repo "$GITHUB_REPOSITORY" --json body --jq '.body' > /tmp/v3.5.6-published.md
-          cmp -s /tmp/v3.5.6-updated.md /tmp/v3.5.6-published.md
-          grep -Fq '## Getting started' /tmp/v3.5.6-published.md
-          grep -Fq 'https://archlinux.org/download/' /tmp/v3.5.6-published.md
-          grep -Fq 'https://wiki.archlinux.org/title/Installation_guide' /tmp/v3.5.6-published.md
-          grep -Fq 'sudo ./awtarchy-install.sh' /tmp/v3.5.6-published.md
-          grep -Fq '## Existing Awtarchy users' /tmp/v3.5.6-published.md
-          grep -Fq 'awtarchy update' /tmp/v3.5.6-published.md
-          grep -Fq '## Validation' /tmp/v3.5.6-published.md
-          grep -Fq '_Placeholder for possible tested post-release patches to v3.5.6._' /tmp/v3.5.6-published.md
-
-          test "$(gh release view v3.5.6 --repo "$GITHUB_REPOSITORY" --json name --jq '.name')" = "$release_name"
-          test "$(gh release view v3.5.6 --repo "$GITHUB_REPOSITORY" --json tagName --jq '.tagName')" = "$release_tag"
-          test "$(gh release view v3.5.6 --repo "$GITHUB_REPOSITORY" --json isDraft --jq '.isDraft')" = "$release_draft"
-          test "$(gh release view v3.5.6 --repo "$GITHUB_REPOSITORY" --json isPrerelease --jq '.isPrerelease')" = "$release_prerelease"
-          test "$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/v3.5.6" --jq '.target_commitish')" = "$release_target"
-
-          final_tag_type="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/v3.5.6" --jq '.object.type')"
-          final_tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/v3.5.6" --jq '.object.sha')"
-          if [[ "$final_tag_type" == 'tag' ]]; then
-            final_tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${final_tag_sha}" --jq '.object.sha')"
-          fi
-          test "$final_tag_sha" = "$tag_sha"
 
           gh api --method DELETE "repos/${GITHUB_REPOSITORY}/git/refs/heads/release/v3.5.6-notes-bridge"

--- a/.github/workflows/validate-bluetooth-state.yml
+++ b/.github/workflows/validate-bluetooth-state.yml
@@ -66,3 +66,112 @@ jobs:
             fi
           done
           (( missing == 0 ))
+
+  repair-v3-5-6-release-notes:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.number == 158 &&
+      github.event.pull_request.head.ref == 'release/v3.5.6-notes-bridge' &&
+      github.event.pull_request.title == 'Release notes bridge: restore v3.5.6 Getting started'
+    needs: bluetooth-state
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout exact release notes bridge
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          ref: release/v3.5.6-notes-bridge
+          fetch-depth: 0
+
+      - name: Restore Getting started section without moving release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_SHA: 1295e13b9323463b735f1793e5251ca4a2529eef
+        run: |
+          set -euo pipefail
+
+          current_main="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" --jq '.object.sha')"
+          test "$current_main" = "$EXPECTED_SHA"
+
+          release_name="$(gh release view v3.5.6 --repo "$GITHUB_REPOSITORY" --json name --jq '.name')"
+          release_tag="$(gh release view v3.5.6 --repo "$GITHUB_REPOSITORY" --json tagName --jq '.tagName')"
+          release_draft="$(gh release view v3.5.6 --repo "$GITHUB_REPOSITORY" --json isDraft --jq '.isDraft')"
+          release_prerelease="$(gh release view v3.5.6 --repo "$GITHUB_REPOSITORY" --json isPrerelease --jq '.isPrerelease')"
+          release_target="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/v3.5.6" --jq '.target_commitish')"
+
+          test "$release_name" = 'Awtarchy v3.5.6 Quickshell'
+          test "$release_tag" = 'v3.5.6'
+          test "$release_draft" = 'false'
+          test "$release_prerelease" = 'false'
+          test "$release_target" = "$EXPECTED_SHA"
+
+          tag_type="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/v3.5.6" --jq '.object.type')"
+          tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/v3.5.6" --jq '.object.sha')"
+          if [[ "$tag_type" == 'tag' ]]; then
+            tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${tag_sha}" --jq '.object.sha')"
+          fi
+          test "$tag_sha" = "$EXPECTED_SHA"
+
+          gh release view v3.5.6 --repo "$GITHUB_REPOSITORY" --json body --jq '.body' > /tmp/v3.5.6-current.md
+          ! grep -Fq '## Getting started' /tmp/v3.5.6-current.md
+          grep -Fq '## Existing Awtarchy users' /tmp/v3.5.6-current.md
+
+          python3 - <<'PY'
+          from pathlib import Path
+
+          path = Path('/tmp/v3.5.6-current.md')
+          body = path.read_text()
+          marker = '## Existing Awtarchy users\n'
+          section = (
+              '## Getting started\n\n'
+              'Awtarchy is an Arch Linux overlay/environment, not a Linux distribution or an Arch Linux installer. Install it onto a working minimal Arch Linux system.\n\n'
+              'If you are starting from zero:\n\n'
+              '1. Download the official Arch Linux ISO from the [Arch Linux download page](https://archlinux.org/download/).\n'
+              '2. Boot the Arch Linux ISO.\n'
+              '3. Install a working minimal Arch Linux system first.\n'
+              '   - For most users, Awtarchy recommends the official `archinstall` guided installer included with the Arch ISO as the easiest path. Run `archinstall` from the live environment and complete a minimal Arch installation.\n'
+              '   - A normal manual Arch installation using the [ArchWiki Installation Guide](https://wiki.archlinux.org/title/Installation_guide) is also fine.\n'
+              '4. Boot into the installed Arch system.\n\n'
+              'Once you have a working minimal Arch installation, install Awtarchy:\n\n'
+              '```bash\n'
+              'sudo pacman -S git --noconfirm\n'
+              'git clone https://github.com/dillacorn/awtarchy\n'
+              'cd awtarchy\n'
+              'sudo ./awtarchy-install.sh\n'
+              '```\n\n'
+          )
+          if body.count(marker) != 1:
+              raise SystemExit('Expected exactly one Existing Awtarchy users heading')
+          updated = body.replace(marker, section + marker, 1)
+          Path('/tmp/v3.5.6-updated.md').write_text(updated)
+          PY
+
+          gh release edit v3.5.6 --repo "$GITHUB_REPOSITORY" --notes-file /tmp/v3.5.6-updated.md
+
+          gh release view v3.5.6 --repo "$GITHUB_REPOSITORY" --json body --jq '.body' > /tmp/v3.5.6-published.md
+          cmp -s /tmp/v3.5.6-updated.md /tmp/v3.5.6-published.md
+          grep -Fq '## Getting started' /tmp/v3.5.6-published.md
+          grep -Fq 'https://archlinux.org/download/' /tmp/v3.5.6-published.md
+          grep -Fq 'https://wiki.archlinux.org/title/Installation_guide' /tmp/v3.5.6-published.md
+          grep -Fq 'sudo ./awtarchy-install.sh' /tmp/v3.5.6-published.md
+          grep -Fq '## Existing Awtarchy users' /tmp/v3.5.6-published.md
+          grep -Fq 'awtarchy update' /tmp/v3.5.6-published.md
+          grep -Fq '## Validation' /tmp/v3.5.6-published.md
+          grep -Fq '_Placeholder for possible tested post-release patches to v3.5.6._' /tmp/v3.5.6-published.md
+
+          test "$(gh release view v3.5.6 --repo "$GITHUB_REPOSITORY" --json name --jq '.name')" = "$release_name"
+          test "$(gh release view v3.5.6 --repo "$GITHUB_REPOSITORY" --json tagName --jq '.tagName')" = "$release_tag"
+          test "$(gh release view v3.5.6 --repo "$GITHUB_REPOSITORY" --json isDraft --jq '.isDraft')" = "$release_draft"
+          test "$(gh release view v3.5.6 --repo "$GITHUB_REPOSITORY" --json isPrerelease --jq '.isPrerelease')" = "$release_prerelease"
+          test "$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/v3.5.6" --jq '.target_commitish')" = "$release_target"
+
+          final_tag_type="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/v3.5.6" --jq '.object.type')"
+          final_tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/v3.5.6" --jq '.object.sha')"
+          if [[ "$final_tag_type" == 'tag' ]]; then
+            final_tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${final_tag_sha}" --jq '.object.sha')"
+          fi
+          test "$final_tag_sha" = "$tag_sha"
+
+          gh api --method DELETE "repos/${GITHUB_REPOSITORY}/git/refs/heads/release/v3.5.6-notes-bridge"


### PR DESCRIPTION
Temporary release-notes-only bridge for Awtarchy v3.5.6.

This PR is intentionally **not for merging**. It corrects only the already-published `v3.5.6` release body by restoring the standard **Getting started** section required by `AGENTS.md` and present in prior stable releases.

The `v3.5.6` tag and release target must remain unchanged at `1295e13b9323463b735f1793e5251ca4a2529eef`. The one-use workflow will verify the current release metadata and tag SHA before editing, update only the release notes body with `gh release edit`, re-read the complete release, verify metadata/tag fidelity, then delete this helper branch.