### PR TITLE
Release notes bridge: align v3.5.6 with canonical guides

### DIFF
--- a/.github/release-v3.5.6-cleanup.md
+++ b/.github/release-v3.5.6-cleanup.md
@@ -1,0 +1,46 @@
+# Awtarchy v3.5.6 Quickshell
+
+Awtarchy v3.5.6 simplifies Battery Care by making TLP the hardware and compatibility authority while keeping Awtarchy's Quickshell controls as a thin generic client. It also includes conservative battery telemetry hardening, bounded clipboard thumbnail rendering, and diagnostics for the still-unresolved Bluetooth resume issue.
+
+## Install and update
+
+Fresh installation: [INSTALL.md](https://github.com/dillacorn/awtarchy/blob/main/INSTALL.md)
+
+Existing Awtarchy installations and stable updates: [UPDATING.md](https://github.com/dillacorn/awtarchy/blob/main/UPDATING.md)
+
+Quick update:
+
+```bash
+awtarchy update
+```
+
+## Battery Care
+
+- TLP now owns vendor/plugin detection, supported threshold values, hardware quirks, validation, and battery writes.
+- Awtarchy's Quickshell Battery Care UI remains as a generic client for numeric ranges and percentage presets explicitly advertised by TLP.
+- Awtarchy persists only standard TLP threshold settings in its owned `/etc/tlp.d/00-awtarchy-battery-care.conf` drop-in and applies them through TLP.
+- Selector-style and other hardware-specific modes stay read-only in Awtarchy and can be managed through TLPUI instead of duplicating TLP's hardware policy.
+- TLPUI uses Arch's normal repository package path alongside TLP after resolving the `power-profiles-daemon` conflict.
+
+## Real-hardware fixes
+
+- Battery Care policy verification now handles protected root-only `/etc/sudoers.d` directories correctly without weakening owner, mode, symlink, marker, or `visudo` checks.
+- Stop-only TLP interfaces can use TLP's normalized logical threshold readback when no standard `power_supply` stop-threshold file exists, while still rejecting values outside TLP's advertised range or presets.
+- Real Sony hardware with TLP 1.10.2 was validated with full charging restored at logical 100%/off and with the 80% preset enabled.
+
+## Other maintenance
+
+- Battery telemetry is conservative around dead or phantom packs and falls back to normal UPower state whenever raw evidence is insufficient.
+- Clipboard thumbnails retain first-frame rendering, bounded ImageMagick memory/map/disk resources, and timeout protection.
+- A one-run suspend/resume diagnostic collector is included for Bluetooth issue #146. It is observational only; v3.5.6 does not claim to fix the intermittent Bluetooth resume behavior.
+
+## Validation
+
+- Exact release target: `1295e13b9323463b735f1793e5251ca4a2529eef`.
+- Battery Care PR #156 passed all 22 pull-request workflows on exact reviewed head `00db570a85a5616a4309c398d7e06dee9228da85`.
+- Final full-charge and 80% Battery Care states were validated on real Sony hardware before merge.
+- All 10 push workflows for the exact merged release target completed successfully, including the full `Validate Awtarchy` integration suite.
+
+## Post-release updates
+
+_Placeholder for possible tested post-release patches to v3.5.6._

--- a/.github/workflows/validate-stable-release-notes.yml
+++ b/.github/workflows/validate-stable-release-notes.yml
@@ -39,3 +39,106 @@ jobs:
         run: bash tests/test-stable-release-notes-validator.sh
       - name: Canonical installation and update docs
         run: bash tests/test-install-update-docs.sh
+
+  cleanup-v3-5-6-release-notes:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.head.ref == 'release/v3.5.6-notes-cleanup' &&
+      github.event.pull_request.title == 'Release notes bridge: align v3.5.6 with canonical guides'
+    needs: release-notes-contract
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+
+      - name: Validate, update, and verify v3.5.6 release notes
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_MAIN_SHA: 2bd8e0d135855634ae82624d202ad461491f7518
+          EXPECTED_RELEASE_SHA: 1295e13b9323463b735f1793e5251ca4a2529eef
+        run: |
+          set -euo pipefail
+
+          current_main="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" --jq '.object.sha')"
+          test "$current_main" = "$EXPECTED_MAIN_SHA"
+
+          gh api "repos/${GITHUB_REPOSITORY}/releases/tags/v3.5.6" > /tmp/v3.5.6-before.json
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          data = json.loads(Path('/tmp/v3.5.6-before.json').read_text(encoding='utf-8'))
+          Path('/tmp/v3.5.6-before.md').write_text(data['body'], encoding='utf-8')
+          assert data['name'] == 'Awtarchy v3.5.6 Quickshell'
+          assert data['tag_name'] == 'v3.5.6'
+          assert data['target_commitish'] == '1295e13b9323463b735f1793e5251ca4a2529eef'
+          assert data['draft'] is False
+          assert data['prerelease'] is False
+          PY
+
+          grep -Fq '## Getting started' /tmp/v3.5.6-before.md
+          grep -Fq '## Existing Awtarchy users' /tmp/v3.5.6-before.md
+          if grep -Fq '## Install and update' /tmp/v3.5.6-before.md; then
+            echo 'v3.5.6 release notes already use the canonical guide format; refusing to overwrite.' >&2
+            exit 1
+          fi
+
+          tag_type="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/v3.5.6" --jq '.object.type')"
+          tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/v3.5.6" --jq '.object.sha')"
+          if [[ "$tag_type" == 'tag' ]]; then
+            tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${tag_sha}" --jq '.object.sha')"
+          fi
+          test "$tag_sha" = "$EXPECTED_RELEASE_SHA"
+
+          gh api "repos/${GITHUB_REPOSITORY}/releases/tags/v3.5.5" > /tmp/v3.5.5.json
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          data = json.loads(Path('/tmp/v3.5.5.json').read_text(encoding='utf-8'))
+          Path('/tmp/v3.5.5.md').write_text(data['body'], encoding='utf-8')
+          PY
+
+          python3 .github/scripts/validate-stable-release-notes.py \
+            --version v3.5.6 \
+            --notes .github/release-v3.5.6-cleanup.md \
+            --previous /tmp/v3.5.5.md
+
+          gh release edit v3.5.6 \
+            --repo "$GITHUB_REPOSITORY" \
+            --notes-file .github/release-v3.5.6-cleanup.md
+
+          gh api "repos/${GITHUB_REPOSITORY}/releases/tags/v3.5.6" > /tmp/v3.5.6-after.json
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          data = json.loads(Path('/tmp/v3.5.6-after.json').read_text(encoding='utf-8'))
+          Path('/tmp/v3.5.6-published.md').write_text(data['body'], encoding='utf-8')
+          assert data['name'] == 'Awtarchy v3.5.6 Quickshell'
+          assert data['tag_name'] == 'v3.5.6'
+          assert data['target_commitish'] == '1295e13b9323463b735f1793e5251ca4a2529eef'
+          assert data['draft'] is False
+          assert data['prerelease'] is False
+          PY
+
+          cmp -s .github/release-v3.5.6-cleanup.md /tmp/v3.5.6-published.md
+
+          python3 .github/scripts/validate-stable-release-notes.py \
+            --version v3.5.6 \
+            --notes /tmp/v3.5.6-published.md \
+            --previous /tmp/v3.5.5.md
+
+          tag_type="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/v3.5.6" --jq '.object.type')"
+          tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/v3.5.6" --jq '.object.sha')"
+          if [[ "$tag_type" == 'tag' ]]; then
+            tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${tag_sha}" --jq '.object.sha')"
+          fi
+          test "$tag_sha" = "$EXPECTED_RELEASE_SHA"
+
+          test "$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" --jq '.object.sha')" = "$EXPECTED_MAIN_SHA"
+
+          gh api --method DELETE "repos/${GITHUB_REPOSITORY}/git/refs/heads/release/v3.5.6-notes-cleanup"


### PR DESCRIPTION
Temporary release-notes-only bridge for Awtarchy v3.5.6.

This PR is intentionally not for merging. It updates only the already-published v3.5.6 release body to match the current canonical release-note format: INSTALL.md and UPDATING.md links instead of duplicated setup instructions, concise release-specific Battery Care/maintenance notes, Validation, and the v3.5.6 Post-release updates placeholder.

The workflow is guarded to this exact PR title/head/base. Before editing it verifies current main, release metadata, release target and tag SHA, confirms the old Getting started format is still published, fetches v3.5.5 for comparison, and runs the permanent stable-release validator. After the edit it re-reads the exact published body, requires byte-for-byte equality with the proposed notes, runs the validator again, re-verifies metadata/tag/main fidelity, and deletes the helper branch.

Do not merge this PR.