### PR TITLE
Release bridge: publish v3.6.0

### DIFF
--- a/.github/release-v3.6.0.md
+++ b/.github/release-v3.6.0.md
@@ -1,0 +1,54 @@
+# Awtarchy v3.6.0 Quickshell
+
+Awtarchy v3.6.0 moves locking fully into Quickshell and adds new privacy and bar controls that were runtime-tested together before release. It also tightens workspace behavior and fixes a few desktop input/indicator regressions.
+
+## Install and update
+
+Fresh installation: [INSTALL.md](https://github.com/dillacorn/awtarchy/blob/main/INSTALL.md)
+
+Existing Awtarchy installations and stable updates: [UPDATING.md](https://github.com/dillacorn/awtarchy/blob/main/UPDATING.md)
+
+Quick update:
+
+```bash
+awtarchy update
+```
+
+## Native Quickshell lockscreen
+
+- Replaces Hyprlock with Awtarchy's native Quickshell `WlSessionLock` + PAM lockscreen.
+- `SUPER+L`, Hypridle, and the Power Menu now use the same Awtarchy lock path.
+- Multi-monitor locking, theme/cursor behavior, and lockscreen power actions are integrated into the Quickshell implementation.
+- Existing Awtarchy installations migrate to the new lockscreen through the normal managed update path.
+
+## Privacy and Quick Settings
+
+- Screen Share Guard can now be controlled from Quick Settings per app/group without editing `hyprland.lua`.
+- Capture allowances can be session-only or persisted by locking the current choice, and **Restore Awtarchy Defaults** returns the guard policy to stock behavior.
+- Adds an Awtarchy Tips `?` shortcut to Quick Settings.
+- Adds optional per-workspace bar hiding for workspaces 1-10 while preserving existing global, per-monitor, fullscreen, and idle visibility behavior.
+
+## Desktop polish
+
+- Regular workspace-switch animations are disabled by default while special-workspace and unrelated animations remain enabled.
+- Brightness wheel input now responds on the first valid scroll step instead of waiting through the previous brightness-only delay.
+- Empty workspace placeholders disappear after focus moves away instead of leaving phantom workspace indicators.
+
+## Release and documentation maintenance
+
+- `INSTALL.md` and `UPDATING.md` are now the canonical installation and update guides linked by stable releases.
+- Stable release notes now pass a permanent structure validator before and after publication.
+
+## Known issue
+
+- Bluetooth suspend/resume issue #146 remains evidence-gated and unresolved. v3.6.0 does not claim to fix that intermittent behavior; the diagnostic capture remains available for the next real reproduction.
+
+## Validation
+
+- Exact release target: `271595d1e78d1cd48f68795e6c1f3fcc060c4471`.
+- The native lockscreen, Screen Share Guard, Quick Settings Tips shortcut, per-workspace bar visibility, brightness-wheel fix, and workspace-indicator fix were runtime-tested before merge.
+- All merged-main push workflows returned for the exact release target completed successfully, including the full `Validate Awtarchy` integration suite and focused lockscreen, Screen Share Guard, workspace, and runtime checks.
+
+## Post-release updates
+
+_Placeholder for possible tested post-release patches to v3.6.0._

--- a/.github/workflows/validate-stable-release-notes.yml
+++ b/.github/workflows/validate-stable-release-notes.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Canonical installation and update docs
         run: bash tests/test-install-update-docs.sh
 
-  publish-v3-6-0:
+  verify-published-v3-6-0:
     if: >-
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.ref == 'release/v3.6.0-bridge' &&
@@ -57,7 +57,7 @@ jobs:
           ref: release/v3.6.0-bridge
           fetch-depth: 0
 
-      - name: Validate and publish v3.6.0
+      - name: Verify published v3.6.0 and clean bridge
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -67,7 +67,7 @@ jobs:
 
           current_main="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" --jq '.object.sha')"
           test "$current_main" = "$EXPECTED_SHA" || {
-            printf 'Refusing release: main moved from %s to %s\n' "$EXPECTED_SHA" "$current_main" >&2
+            printf 'Refusing cleanup: main moved from %s to %s\n' "$EXPECTED_SHA" "$current_main" >&2
             false
           }
 
@@ -77,36 +77,14 @@ jobs:
             --notes .github/release-v3.6.0.md \
             --previous /tmp/previous-stable-release.md
 
-          if gh release view v3.6.0 --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            printf '%s\n' 'Refusing release: v3.6.0 release already exists.' >&2
-            false
-          fi
-
-          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/v3.6.0" >/dev/null 2>&1; then
-            printf '%s\n' 'Refusing release: v3.6.0 tag already exists.' >&2
-            false
-          fi
-
-          runs_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${EXPECTED_SHA}&event=push&per_page=100")"
-          run_count="$(jq '.total_count' <<<"$runs_json")"
-          bad_runs="$(jq '[.workflow_runs[] | select(.status != "completed" or .conclusion != "success")] | length' <<<"$runs_json")"
-          validate_runs="$(jq '[.workflow_runs[] | select(.name == "Validate Awtarchy" and .status == "completed" and .conclusion == "success")] | length' <<<"$runs_json")"
-          (( run_count > 0 ))
-          (( bad_runs == 0 ))
-          (( validate_runs > 0 ))
-
-          gh release create v3.6.0 \
-            --repo "$GITHUB_REPOSITORY" \
-            --target "$EXPECTED_SHA" \
-            --title 'Awtarchy v3.6.0 Quickshell' \
-            --notes-file .github/release-v3.6.0.md
-
-          gh release view v3.6.0 --repo "$GITHUB_REPOSITORY" --json body --jq '.body' > /tmp/published-release.md
+          published_body="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/v3.6.0" --jq '.body')"
+          expected_body="$(cat .github/release-v3.6.0.md)"
+          test "$published_body" = "$expected_body"
+          printf '%s\n' "$published_body" > /tmp/published-release.md
           python3 .github/scripts/validate-stable-release-notes.py \
             --version v3.6.0 \
             --notes /tmp/published-release.md \
             --previous /tmp/previous-stable-release.md
-          cmp -s .github/release-v3.6.0.md /tmp/published-release.md
 
           release_name="$(gh release view v3.6.0 --repo "$GITHUB_REPOSITORY" --json name --jq '.name')"
           release_tag="$(gh release view v3.6.0 --repo "$GITHUB_REPOSITORY" --json tagName --jq '.tagName')"
@@ -130,7 +108,5 @@ jobs:
             false
           }
 
-          gh release view v3.6.0 --repo "$GITHUB_REPOSITORY" --json name,tagName,isDraft,isPrerelease,url
-          printf 'Verified v3.6.0 tag target: %s\n' "$tag_sha"
-
+          printf 'Verified published v3.6.0 at %s\n' "$tag_sha"
           gh api --method DELETE "repos/${GITHUB_REPOSITORY}/git/refs/heads/release/v3.6.0-bridge"

--- a/.github/workflows/validate-stable-release-notes.yml
+++ b/.github/workflows/validate-stable-release-notes.yml
@@ -39,3 +39,98 @@ jobs:
         run: bash tests/test-stable-release-notes-validator.sh
       - name: Canonical installation and update docs
         run: bash tests/test-install-update-docs.sh
+
+  publish-v3-6-0:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.ref == 'release/v3.6.0-bridge' &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.title == 'Release bridge: publish v3.6.0'
+    needs: release-notes-contract
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout exact release bridge
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          ref: release/v3.6.0-bridge
+          fetch-depth: 0
+
+      - name: Validate and publish v3.6.0
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_SHA: 271595d1e78d1cd48f68795e6c1f3fcc060c4471
+        run: |
+          set -euo pipefail
+
+          current_main="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" --jq '.object.sha')"
+          test "$current_main" = "$EXPECTED_SHA" || {
+            printf 'Refusing release: main moved from %s to %s\n' "$EXPECTED_SHA" "$current_main" >&2
+            false
+          }
+
+          gh release view v3.5.6 --repo "$GITHUB_REPOSITORY" --json body --jq '.body' > /tmp/previous-stable-release.md
+          python3 .github/scripts/validate-stable-release-notes.py \
+            --version v3.6.0 \
+            --notes .github/release-v3.6.0.md \
+            --previous /tmp/previous-stable-release.md
+
+          if gh release view v3.6.0 --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            printf '%s\n' 'Refusing release: v3.6.0 release already exists.' >&2
+            false
+          fi
+
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/v3.6.0" >/dev/null 2>&1; then
+            printf '%s\n' 'Refusing release: v3.6.0 tag already exists.' >&2
+            false
+          fi
+
+          runs_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${EXPECTED_SHA}&event=push&per_page=100")"
+          run_count="$(jq '.total_count' <<<"$runs_json")"
+          bad_runs="$(jq '[.workflow_runs[] | select(.status != "completed" or .conclusion != "success")] | length' <<<"$runs_json")"
+          validate_runs="$(jq '[.workflow_runs[] | select(.name == "Validate Awtarchy" and .status == "completed" and .conclusion == "success")] | length' <<<"$runs_json")"
+          (( run_count > 0 ))
+          (( bad_runs == 0 ))
+          (( validate_runs > 0 ))
+
+          gh release create v3.6.0 \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$EXPECTED_SHA" \
+            --title 'Awtarchy v3.6.0 Quickshell' \
+            --notes-file .github/release-v3.6.0.md
+
+          gh release view v3.6.0 --repo "$GITHUB_REPOSITORY" --json body --jq '.body' > /tmp/published-release.md
+          python3 .github/scripts/validate-stable-release-notes.py \
+            --version v3.6.0 \
+            --notes /tmp/published-release.md \
+            --previous /tmp/previous-stable-release.md
+          cmp -s .github/release-v3.6.0.md /tmp/published-release.md
+
+          release_name="$(gh release view v3.6.0 --repo "$GITHUB_REPOSITORY" --json name --jq '.name')"
+          release_tag="$(gh release view v3.6.0 --repo "$GITHUB_REPOSITORY" --json tagName --jq '.tagName')"
+          release_draft="$(gh release view v3.6.0 --repo "$GITHUB_REPOSITORY" --json isDraft --jq '.isDraft')"
+          release_prerelease="$(gh release view v3.6.0 --repo "$GITHUB_REPOSITORY" --json isPrerelease --jq '.isPrerelease')"
+          release_target="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/v3.6.0" --jq '.target_commitish')"
+
+          test "$release_name" = 'Awtarchy v3.6.0 Quickshell'
+          test "$release_tag" = 'v3.6.0'
+          test "$release_draft" = 'false'
+          test "$release_prerelease" = 'false'
+          test "$release_target" = "$EXPECTED_SHA"
+
+          tag_type="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/v3.6.0" --jq '.object.type')"
+          tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/v3.6.0" --jq '.object.sha')"
+          if [[ "$tag_type" == 'tag' ]]; then
+            tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${tag_sha}" --jq '.object.sha')"
+          fi
+          test "$tag_sha" = "$EXPECTED_SHA" || {
+            printf 'Release tag points to %s, expected %s\n' "$tag_sha" "$EXPECTED_SHA" >&2
+            false
+          }
+
+          gh release view v3.6.0 --repo "$GITHUB_REPOSITORY" --json name,tagName,isDraft,isPrerelease,url
+          printf 'Verified v3.6.0 tag target: %s\n' "$tag_sha"
+
+          gh api --method DELETE "repos/${GITHUB_REPOSITORY}/git/refs/heads/release/v3.6.0-bridge"


### PR DESCRIPTION
One-use release bridge for Awtarchy v3.6.0.

This PR is intentionally not for merging. Its guarded workflow publishes `v3.6.0` only from exact verified `main` commit `271595d1e78d1cd48f68795e6c1f3fcc060c4471`, validates the proposed release notes against the permanent stable-release contract, verifies current merged-main CI, publishes the release, re-validates the published body, verifies release metadata and tag SHA, then deletes the helper branch.

Do not merge this PR.